### PR TITLE
Introduce KAT KEM tests

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2,3 +2,4 @@ pub const CRYPTO_PUBLICKEYBYTES: usize = 1357824;
 pub const CRYPTO_SECRETKEYBYTES: usize = 14120;
 pub const CRYPTO_CIPHERTEXTBYTES: usize = 240;
 pub const CRYPTO_BYTES: usize = 32;
+pub const CRYPTO_PRIMITIVE: &str = "mceliece348864";

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,3 +29,120 @@ fn main() {
 
     //test_transpose::test_transpose();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Write;
+    use std::error::Error;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct CryptoError<'a>(&'a str, i32);
+
+    impl<'a> fmt::Display for CryptoError<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{} returned <{}>", self.0, self.1)
+        }
+    }
+
+    impl<'a> Error for CryptoError<'a> {}
+
+    #[test]
+    fn test_kat_tests() -> Result<(), Box<dyn Error>> {
+        const KATNUM: usize = 10;
+
+        let mut entropy_input = [0u8; 48];
+        let mut seed = [[0u8; 48]; KATNUM];
+
+        for i in 0..48 {
+            entropy_input[i] = i as u8;
+        }
+        randombytes::randombytes_init(&mut entropy_input, &[0u8; 48], 256)?;
+
+        for i in 0..KATNUM {
+            randombytes::randombytes(&mut seed[i], 48)?;
+        }
+
+        let fp_req = &mut File::create("kat_kem.req")?;
+
+        for i in 0..KATNUM {
+            kat_test_request(fp_req, i, &seed[i])?;
+        }
+
+        let fp_rsp = &mut File::create("kat_kem.rsp")?;
+        writeln!(fp_rsp, "# kem/{}\n", api::CRYPTO_PRIMITIVE)?;
+
+        for i in 0..KATNUM {
+            kat_test_response(fp_rsp, i, &seed[i])?;
+        }
+
+        Ok(())
+    }
+
+    fn kat_test_request(fp_req: &mut File, i: usize, seed: &[u8; 48]) -> Result<(), Box<dyn Error>> {
+        writeln!(fp_req, "count = {}", i)?;
+        writeln!(fp_req, "seed = {}", repr_binary_str(seed))?;
+        writeln!(fp_req, "pk =")?;
+        writeln!(fp_req, "sk =")?;
+        writeln!(fp_req, "ct =")?;
+        writeln!(fp_req, "ss =\n")?;
+        Ok(())
+    }
+
+    fn kat_test_response(fp_rsp: &mut File, i: usize, seed: &[u8; 48]) -> Result<(), Box<dyn Error>> {
+        let mut ct = [0u8; api::CRYPTO_CIPHERTEXTBYTES];
+        let mut ss = [0u8; api::CRYPTO_BYTES];
+        let mut ss1 = [0u8; api::CRYPTO_BYTES];
+        let mut pk = [0u8; api::CRYPTO_PUBLICKEYBYTES];
+        let mut sk = [0u8; api::CRYPTO_SECRETKEYBYTES];
+
+        randombytes::randombytes_init(seed, &[0u8; 48], 256)?;
+
+        writeln!(fp_rsp, "count = {}", i)?;
+        writeln!(fp_rsp, "seed = {}", repr_binary_str(seed))?;
+
+        let ret_kp = operations::crypto_kem_keypair(&mut pk, &mut sk);
+        if ret_kp != 0 {
+            return Err(Box::new(CryptoError("crypto_kem_keypair", ret_kp)));
+        }
+
+        writeln!(fp_rsp, "pk = {}", repr_binary_str(&pk))?;
+        writeln!(fp_rsp, "sk = {}", repr_binary_str(&sk))?;
+
+        let ret_enc = operations::crypto_kem_enc(&mut ct, &mut ss, &mut pk);
+        if ret_enc != 0 {
+            return Err(Box::new(CryptoError("crypto_kem_enc", ret_enc)));
+        }
+
+        writeln!(fp_rsp, "ct = {}", repr_binary_str(&ct))?;
+        writeln!(fp_rsp, "ss = {}", repr_binary_str(&ss))?;
+        writeln!(fp_rsp, "")?;
+
+        let ret_dec = operations::crypto_kem_dec(&mut ss1, &mut ct, &mut sk);
+        if ret_dec != 0 {
+            return Err(Box::new(CryptoError("crypto_kem_dec", ret_dec)));
+        }
+
+        if ss != ss1 {
+            return Err(Box::new(CryptoError("crypto_kem_dec ss cmp", 1)));
+        }
+
+        Ok(())
+    }
+
+    fn repr_binary_str(a: &[u8]) -> String {
+        let mut s = String::new();
+
+        for v in a.iter() {
+            s.push_str(&format!("{:02X}", v));
+        }
+
+        if a.is_empty() {
+            s.push_str("00");
+        }
+
+        s
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,8 @@ mod tests {
         let mut ct = [0u8; api::CRYPTO_CIPHERTEXTBYTES];
         let mut ss = [0u8; api::CRYPTO_BYTES];
         let mut ss1 = [0u8; api::CRYPTO_BYTES];
-        let mut pk = [0u8; api::CRYPTO_PUBLICKEYBYTES];
-        let mut sk = [0u8; api::CRYPTO_SECRETKEYBYTES];
+        let mut pk = vec![0u8; api::CRYPTO_PUBLICKEYBYTES];
+        let mut sk = vec![0u8; api::CRYPTO_SECRETKEYBYTES];
 
         randombytes::randombytes_init(seed, &[0u8; 48], 256)?;
 


### PR DESCRIPTION
* The generated request file equals the request file generated by the C ref impl (i.e. the RNG generates the same values)
* However, when generating the response file, a stack overflow occurs when calling `operations::crypto_kem_keypair` … I don't know why yet

```
[…]
test transpose::tests::test_transpose ... ok
test uint64_sort::tests::test_uint64_minmax ... ok
test uint64_sort::tests::test_uint64_sort ... ok

thread 'tests::test_kat_tests' has overflowed its stack
fatal runtime error: stack overflow
error: test failed, to rerun pass '--bin classic-mceliece'

Caused by:
  process didn't exit successfully: `/repo-github-prokls/target/debug/deps/classic_mceliece-9ba6e905e7fe049c` (signal: 6, SIGABRT: process abort signal)
Exception: cargo exited with 101
```