### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //! for one specific variant (among ten). Thus the array lengths will be different if you specify
 //! a different variant via feature flags.
 
+#![forbid(unsafe_code)]
+
 mod api;
 mod benes;
 mod bm;


### PR DESCRIPTION
A tiny change. But it makes it harder to accidentally add unsafe code, also makes it clearer to a reader/auditor that the library is indeed only safe Rust.