### PR TITLE
refactor!: Re-write public API to take a `CryptoRng`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,18 @@ repository = "https://github.com/Colfenor/classic-mceliece-rust"
 readme = "README.md"
 license = "MIT"
 version = "1.0.1"
-authors = ["Bernhard Berg <b.b_erg@outlook.com>", "Lukas Prokop <admin@lukas-prokop.at>"]
+authors = [
+    "Bernhard Berg <b.b_erg@outlook.com>",
+    "Lukas Prokop <admin@lukas-prokop.at>",
+    "Daniel Kales <daniel.kales@gmail.com>",
+]
 edition = "2021"
 keywords = ["pqc", "post-quantum", "cryptography", "lattice"]
 categories = ["cryptography"]
 
 [dependencies]
-rand = "0.8.4"
-sha3 = "0.9.1"
-lazy_static = "1.4.0"
-aes = "0.7.5"
-hex = "0.4.3"
-block-modes = "0.8.1"
+rand = { version = "0.8", default-features = false }
+sha3 = "0.10"
 
 [features]
 default = []
@@ -36,8 +36,12 @@ name = "kem_api"
 harness = false
 
 [dev-dependencies]
-criterion = { version = "0.3", "features" = [ "html_reports" ] }
+rand = { version = "0.8", features = ["default"] }
+criterion = { version = "0.3", features = ["html_reports"] }
 criterion-cycles-per-byte = "0.1.2"
+aes = "0.7"
+block-modes = "0.8"
+hex = "0.4.3"
 
 [profile.dev]
-opt-level = 1  # reduces runtime for KATNUM=2 from 281s to 11s
+opt-level = 1 # reduces runtime for KATNUM=2 from 281s to 11s

--- a/benches/kem_api.rs
+++ b/benches/kem_api.rs
@@ -1,14 +1,13 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use criterion_cycles_per_byte::CyclesPerByte;
 
-use classic_mceliece_rust::AesState;
 use classic_mceliece_rust::{crypto_kem_dec, crypto_kem_enc, crypto_kem_keypair};
 use classic_mceliece_rust::{
     CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES,
 };
 
 pub fn bench_complete_kem(criterion: &mut Criterion<CyclesPerByte>) {
-    let mut rng = AesState::new();
+    let mut rng = rand::thread_rng();
     let mut pk = [0u8; CRYPTO_PUBLICKEYBYTES];
     let mut sk = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut ct = [0u8; CRYPTO_CIPHERTEXTBYTES];
@@ -26,7 +25,7 @@ pub fn bench_complete_kem(criterion: &mut Criterion<CyclesPerByte>) {
 }
 
 pub fn bench_kem_keypair(criterion: &mut Criterion<CyclesPerByte>) {
-    let mut rng = AesState::new();
+    let mut rng = rand::thread_rng();
     let mut pk = [0u8; CRYPTO_PUBLICKEYBYTES];
     let mut sk = [0u8; CRYPTO_SECRETKEYBYTES];
 
@@ -38,7 +37,7 @@ pub fn bench_kem_keypair(criterion: &mut Criterion<CyclesPerByte>) {
 }
 
 pub fn bench_kem_enc(criterion: &mut Criterion<CyclesPerByte>) {
-    let mut rng = AesState::new();
+    let mut rng = rand::thread_rng();
     let mut pk = [0u8; CRYPTO_PUBLICKEYBYTES];
     let mut sk = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut ct = [0u8; CRYPTO_CIPHERTEXTBYTES];
@@ -54,7 +53,7 @@ pub fn bench_kem_enc(criterion: &mut Criterion<CyclesPerByte>) {
 }
 
 pub fn bench_kem_dec(criterion: &mut Criterion<CyclesPerByte>) {
-    let mut rng = AesState::new();
+    let mut rng = rand::thread_rng();
     let mut pk = [0u8; CRYPTO_PUBLICKEYBYTES];
     let mut sk = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut ct = [0u8; CRYPTO_CIPHERTEXTBYTES];

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,16 +1,15 @@
 //! Simple example illustrating shared key negotiation.
 
-use classic_mceliece_rust::AesState;
 use classic_mceliece_rust::{crypto_kem_dec, crypto_kem_enc, crypto_kem_keypair};
 use classic_mceliece_rust::{
     CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES,
 };
 
-use hex;
+use rand::thread_rng;
 use std::error;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
-    let mut rng = AesState::new();
+    let mut rng = thread_rng();
     let mut pk = [0u8; CRYPTO_PUBLICKEYBYTES];
     let mut sk = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut ct = [0u8; CRYPTO_CIPHERTEXTBYTES];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ mod int32_sort;
 mod operations;
 mod params;
 mod pk_gen;
-mod randombytes;
 mod root;
 mod sk_gen;
 mod synd;
@@ -26,12 +25,14 @@ mod transpose;
 mod uint64_sort;
 mod util;
 
+#[cfg(test)]
+mod nist_aes_rng;
+
 pub use api::{
     CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PRIMITIVE, CRYPTO_PUBLICKEYBYTES,
     CRYPTO_SECRETKEYBYTES,
 };
 pub use operations::{crypto_kem_dec, crypto_kem_enc, crypto_kem_keypair};
-pub use randombytes::{AesState, RNGState};
 
 mod macros {
     /// This macro(A, B, C, T) allows to get “&A[B..B+C]” of type “&[T]” as type “&[T; C]”.

--- a/src/nist_aes_rng.rs
+++ b/src/nist_aes_rng.rs
@@ -6,21 +6,12 @@
 
 use aes::BlockEncrypt;
 use aes::NewBlockCipher;
-use std::error;
+use rand::CryptoRng;
+use rand::RngCore;
 use std::fmt;
 
-/// Trait requiring primitives to generate pseudo-random numbers.
-/// `AesState` is an object implementing this trait.
-pub trait RNGState {
-    /// Fill the buffer `x` with pseudo-random bytes resulting from the
-    /// RNG run updating the RNG state
-    fn randombytes(&mut self, x: &mut [u8]) -> Result<(), Box<dyn error::Error>>;
-    /// Initialize/reset the RNG state based on the seed provided as `entropy_input`
-    fn randombytes_init(&mut self, entropy_input: [u8; 48]);
-}
-
 /// AesState is a struct storing data of a pseudo-random number generator.
-/// Using `randombytes_init`, it can be initialized once. Using `randombytes`,
+/// Using `randombytes_init`, it can be initialized once. Using the `RngCore` interface,
 /// one can successively fetch new pseudo-random numbers.
 #[derive(Clone, Debug, PartialEq)]
 pub struct AesState {
@@ -75,30 +66,9 @@ impl AesState {
         key[16..32].copy_from_slice(&temp[1]);
         v.copy_from_slice(&temp[2]);
     }
-}
-
-impl RNGState for AesState {
-    /// Fill the buffer `x` with pseudo-random bytes resulting from the
-    /// AES run in counter mode updating the object state
-    fn randombytes(&mut self, x: &mut [u8]) -> Result<(), Box<dyn error::Error>> {
-        for chunk in x.chunks_mut(16) {
-            let count = u128::from_be_bytes(self.v);
-            self.v.copy_from_slice(&(count + 1).to_be_bytes());
-
-            let mut block = [0u8; 16];
-            Self::aes256_ecb(&self.key, &self.v, &mut block);
-
-            (*chunk).copy_from_slice(&block[..chunk.len()]);
-        }
-
-        Self::aes256_ctr_update(&mut None, &mut self.key, &mut self.v);
-        self.reseed_counter += 1;
-
-        Ok(())
-    }
 
     /// Initialize/reset the state based on the seed provided as `entropy_input`
-    fn randombytes_init(&mut self, entropy_input: [u8; 48]) {
+    pub fn randombytes_init(&mut self, entropy_input: [u8; 48]) {
         self.key = [0u8; 32];
         self.v = [0u8; 16];
         self.reseed_counter = 1i32;
@@ -126,13 +96,47 @@ impl fmt::Display for AesState {
     }
 }
 
+impl RngCore for AesState {
+    fn next_u32(&mut self) -> u32 {
+        unimplemented!()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        unimplemented!()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        for chunk in dest.chunks_mut(16) {
+            let count = u128::from_be_bytes(self.v);
+            self.v.copy_from_slice(&(count + 1).to_be_bytes());
+
+            let mut block = [0u8; 16];
+            Self::aes256_ecb(&self.key, &self.v, &mut block);
+
+            (*chunk).copy_from_slice(&block[..chunk.len()]);
+        }
+
+        Self::aes256_ctr_update(&mut None, &mut self.key, &mut self.v);
+        self.reseed_counter += 1;
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+impl CryptoRng for AesState {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::convert::TryFrom;
 
+    const RNG_REF1 : &str= "061550234D158C5EC95595FE04EF7A25767F2E24CC2BC479D09D86DC9ABCFDE7056A8C266F9EF97ED08541DBD2E1FFA19810F5392D076276EF41277C3AB6E94A4E3B7DCC104A05BB089D338BF55C72CAB375389A94BB920BD5D6DC9E7F2EC6FDE028B6F5724BB039F3652AD98DF8CE6C97013210B84BBE81388C3D141D61957C73BCDC5E5CD92525F46A2B757B03CAB5C337004A2DA35324A325713564DAE28F57ACC6DBE32A0726190BAA6B8A0A255AA1AD01E8DD569AA36D096256C420718A69D46D8DB1C6DD40606A0BE3C235BEFE623A90593F82D6A8F9F924E44E36BE87F7D26B8445966F9EE329C426C12521E85F6FD4ECD5D566BA0A3487125D79CC64";
+    const RNG_REF2 : &str= "C17E034061ED5EA817C41D61636281E816F817DCF753A91D97C018FF82FBC9B1728FC66AF114B57978FB6082B70D285140B26725AA5F7BB4409820F67E2D656EDACA30B5BB12EB5249CC3809B188CF0CC95B5AE0EFE8FC5887152CB6601B4CCF9FC411894FA0C0264EB51A481D4D7074FDF065053030C8A92BFCDD06BF18C8489C38D03784FD63001830E5A385A4A37866693F5BDAB8A8A25B519DDBF2D28268601D95BEED647E430484A227C023B0297A282F06C91376433BDE5EC3ABBA8C06B830C26452EA2FA7EDEA8DCFE20EAFCF8980B3D5AECEF89DD861ACEC1F5F7CD2AE6B3CDE3C1D80A2830DD0B9E8468AFAD161981074BEB33DF1CDFF9A5214F9F0";
+
     #[test]
-    fn test_rng() -> Result<(), Box<dyn error::Error>> {
+    fn test_rng_rand_interface() {
         let mut data = [0u8; 256];
         let mut entropy_input = [0u8; 48];
         let mut personalization_string = [0u8; 48];
@@ -140,21 +144,19 @@ mod tests {
 
         for i in 0..48 {
             entropy_input[i] = i as u8;
-            personalization_string[i] = 0 as u8;
+            personalization_string[i] = 0;
         }
 
         rng_state.randombytes_init(entropy_input);
 
-        rng_state.randombytes(&mut data)?;
-        let ref1_src = crate::TestData::new().u8vec("rng_ref1");
+        rng_state.fill_bytes(&mut data);
+        let ref1_src = hex::decode(RNG_REF1).unwrap();
         let ref1 = <[u8; 256]>::try_from(ref1_src).unwrap();
         assert_eq!(data, ref1);
 
-        rng_state.randombytes(&mut data)?;
-        let ref2_src = crate::TestData::new().u8vec("rng_ref2");
+        rng_state.fill_bytes(&mut data);
+        let ref2_src = hex::decode(RNG_REF2).unwrap();
         let ref2 = <[u8; 256]>::try_from(ref2_src).unwrap();
         assert_eq!(data, ref2);
-
-        Ok(())
     }
 }


### PR DESCRIPTION
This changes the public API to take a `CryptoRng + RngCore` instead of the included AES Rng used for the KATs.
A lot of dependencies were moved to `dev-dependencies`, cleaning up the required deps.

BREAKING CHANGE: This changes the public API.


I only quickly tested against the 10 KATs provided by the round3 submission package for the 348864 version, that works, a full KAT test for all features should be done still (@prokls do you have that all set up locally? Otherwise I can do it later).