### PR TITLE
Upgrade sha3 and use shake256 infallibly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography"]
 
 [dependencies]
 rand = "0.8.4"
-sha3 = "0.9.1"
+sha3 = "0.10.2"
 lazy_static = "1.4.0"
 aes = "0.7.5"
 hex = "0.4.3"

--- a/src/crypto_hash.rs
+++ b/src/crypto_hash.rs
@@ -1,51 +1,28 @@
 //! Hash function implementations (only SHAKE)
 
-use std::error;
-use std::fmt;
-use std::io::Read;
-
 use sha3::digest::{ExtendableOutput, Update};
 use sha3::Shake256;
 
-#[derive(Debug)]
-struct ShakeIOError(String);
-
-impl error::Error for ShakeIOError {}
-
-impl fmt::Display for ShakeIOError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "shake failed to read data: {}", self.0)
-    }
-}
-
 /// Utilizes the SHAKE256 hash function. Input and output is of arbitrary length.
-pub(crate) fn shake256(output: &mut [u8], input: &[u8]) -> Result<(), Box<dyn error::Error>> {
+pub(crate) fn shake256(output: &mut [u8], input: &[u8]) {
     let mut shake_hash_fn = Shake256::default();
     shake_hash_fn.update(input);
-
-    let mut result_shake = shake_hash_fn.finalize_xof();
-    match result_shake.read(output) {
-        Ok(_) => Ok(()),
-        Err(e) => Err(Box::new(ShakeIOError(e.to_string()))),
-    }
+    shake_hash_fn.finalize_xof_into(output);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::error;
 
     #[test]
-    fn test_shake256() -> Result<(), Box<dyn error::Error>> {
+    fn test_shake256() {
         let compare_array = crate::TestData::new().u8vec("shake256_digest_expected");
 
         let mut c = [0u8; 448];
         let mut two_e = [0u8; 1025];
         two_e[0] = 2;
 
-        shake256(&mut c[208..=239], &two_e[0..1025])?;
+        shake256(&mut c[208..=239], &two_e[0..1025]);
         assert_eq!(&c, compare_array.as_slice());
-
-        Ok(())
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -61,12 +61,12 @@ pub fn crypto_kem_enc(
 
     encrypt(c, pk, sub!(mut two_e, 1, SYS_N / 8), rng)?;
 
-    shake256(&mut c[SYND_BYTES..SYND_BYTES + 32], &two_e)?;
+    shake256(&mut c[SYND_BYTES..SYND_BYTES + 32], &two_e);
 
     one_ec[1..1 + SYS_N / 8].copy_from_slice(&two_e[1..1 + SYS_N / 8]);
     one_ec[1 + SYS_N / 8..1 + SYS_N / 8 + SYND_BYTES + 32].copy_from_slice(&c[0..SYND_BYTES + 32]);
 
-    shake256(&mut key[0..32], &one_ec)?;
+    shake256(&mut key[0..32], &one_ec);
 
     Ok(())
 }
@@ -93,13 +93,13 @@ pub fn crypto_kem_enc(
 
     encrypt(c, pk, sub!(mut two_e, 1, SYS_N / 8), rng)?;
 
-    shake256(&mut c[SYND_BYTES..(SYND_BYTES + 32)], &two_e)?;
+    shake256(&mut c[SYND_BYTES..(SYND_BYTES + 32)], &two_e);
 
     one_ec[1..1 + (SYS_N / 8)].copy_from_slice(&two_e[1..(SYS_N / 8) + 1]);
     one_ec[1 + (SYS_N / 8)..1 + (SYS_N / 8) + SYND_BYTES + 32]
         .copy_from_slice(&c[0..SYND_BYTES + 32]);
 
-    shake256(&mut key[0..32], &one_ec)?;
+    shake256(&mut key[0..32], &one_ec);
 
     // clear outputs (set to all 0's) if padding bits are not all zero
 
@@ -138,7 +138,7 @@ pub fn crypto_kem_dec(
         sub!(c, 0, SYND_BYTES),
     )?;
 
-    shake256(&mut conf[0..32], &two_e)?;
+    shake256(&mut conf[0..32], &two_e);
 
     let mut ret_confirm: u8 = 0;
     for i in 0..32 {
@@ -159,7 +159,7 @@ pub fn crypto_kem_dec(
 
     (&mut preimage[1 + (SYS_N / 8)..])[0..SYND_BYTES + 32].copy_from_slice(&c[0..SYND_BYTES + 32]);
 
-    shake256(&mut key[0..32], &preimage)?;
+    shake256(&mut key[0..32], &preimage);
 
     Ok(0)
 }
@@ -188,7 +188,7 @@ pub fn crypto_kem_dec(
         sub!(c, 0, SYND_BYTES),
     )?;
 
-    shake256(&mut conf[0..32], &two_e)?;
+    shake256(&mut conf[0..32], &two_e);
 
     let mut ret_confirm: u8 = 0;
     for i in 0..32 {
@@ -209,7 +209,7 @@ pub fn crypto_kem_dec(
 
     (&mut preimage[1 + (SYS_N / 8)..])[0..SYND_BYTES + 32].copy_from_slice(&c[0..SYND_BYTES + 32]);
 
-    shake256(&mut key[0..32], &preimage)?;
+    shake256(&mut key[0..32], &preimage);
 
     // clear outputs (set to all 1's) if padding bits are not all zero
 
@@ -274,7 +274,7 @@ pub fn crypto_kem_keypair(
 
     loop {
         // expanding and updating the seed
-        shake256(&mut r[..], &seed[0..33])?;
+        shake256(&mut r[..], &seed[0..33]);
 
         sk[..32].clone_from_slice(&seed[1..]);
         seed[1..].clone_from_slice(&r[r.len() - 32..]);


### PR DESCRIPTION
SHAKE256 output can be obtained infallibly. We only had an error branch here because the read was done using `std::io::Read::read` instead of directly from `XofReader::read`. The error that was here could not actually happen. Because the `std::io::Read` impl on `XofReader` was infallible, it was just forced to have a `Result` as the return type due to how the trait is defined.

I also took the opportunity to upgrade `sha3`. This is not strictly needed to make it infallible, but I figured we better get the latest dependencies anyway.