### PR TITLE
Use native int load and store instead of homegrown bitshifts

### DIFF
--- a/src/benes.rs
+++ b/src/benes.rs
@@ -142,14 +142,14 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
 
     if rev == 0 {
         for i in 0..64 {
-            bs[i] = util::load8(sub!(r, i * 8, 8));
+            bs[i] = u64::from_le_bytes(*sub!(r, i * 8, 8));
         }
 
         transpose::transpose_64x64_inplace(&mut bs);
 
         for low in 0..6 {
             for i in 0..64 {
-                cond[i] = util::load4(sub!(bits, low * 256 + i * 4, 4)) as u64;
+                cond[i] = u32::from_le_bytes(*sub!(bits, low * 256 + i * 4, 4)) as u64;
             }
             transpose::transpose_64x64_inplace(&mut cond);
             layer(&mut bs, &cond, low);
@@ -159,13 +159,13 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
 
         for low in 0..6 {
             for i in 0..32 {
-                cond[i] = util::load8(sub!(bits, (low + 6) * 256 + i * 8, 8));
+                cond[i] = u64::from_le_bytes(*sub!(bits, (low + 6) * 256 + i * 8, 8));
             }
             layer(&mut bs, &cond, low);
         }
         for low in (0..5).rev() {
             for i in 0..32 {
-                cond[i] = util::load8(sub!(bits, (4 - low + 6 + 6) * 256 + i * 8, 8));
+                cond[i] = u64::from_le_bytes(*sub!(bits, (4 - low + 6 + 6) * 256 + i * 8, 8));
             }
             layer(&mut bs, &cond, low);
         }
@@ -174,7 +174,8 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
 
         for low in (0..6).rev() {
             for i in 0..64 {
-                cond[i] = util::load4(sub!(bits, (5 - low + 6 + 6 + 5) * 256 + i * 4, 4)) as u64;
+                cond[i] =
+                    u32::from_le_bytes(*sub!(bits, (5 - low + 6 + 6 + 5) * 256 + i * 4, 4)) as u64;
             }
             transpose::transpose_64x64_inplace(&mut cond);
             layer(&mut bs, &cond, low);
@@ -187,7 +188,7 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
         }
     } else {
         for i in 0..64 {
-            bs[i] = util::load8(sub!(r, i * 8, 8));
+            bs[i] = u64::from_le_bytes(*sub!(r, i * 8, 8));
         }
 
         transpose::transpose_64x64_inplace(&mut bs);
@@ -195,7 +196,8 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
         for low in 0..6 {
             for i in 0..64 {
                 cond[i] =
-                    util::load4(sub!(bits, (2 * GFBITS - 2) * 256 - low * 256 + i * 4, 4)) as u64;
+                    u32::from_le_bytes(*sub!(bits, (2 * GFBITS - 2) * 256 - low * 256 + i * 4, 4))
+                        as u64;
             }
             transpose::transpose_64x64_inplace(&mut cond);
             layer(&mut bs, &cond, low);
@@ -205,7 +207,7 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
 
         for low in 0..6 {
             for i in 0..32 {
-                cond[i] = util::load8(sub!(
+                cond[i] = u64::from_le_bytes(*sub!(
                     bits,
                     (2 * GFBITS - 2 - 6) * 256 - low * 256 + i * 8,
                     8
@@ -215,7 +217,7 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
         }
         for low in (0..5).rev() {
             for i in 0..32 {
-                cond[i] = util::load8(sub!(
+                cond[i] = u64::from_le_bytes(*sub!(
                     bits,
                     (2 * GFBITS - 2 - 6 - 6) * 256 - (4 - low) * 256 + i * 8,
                     8
@@ -228,7 +230,7 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
 
         for low in (0..6).rev() {
             for i in 0..64 {
-                cond[i] = util::load4(sub!(
+                cond[i] = u32::from_le_bytes(*sub!(
                     bits,
                     (2 * GFBITS - 2 - 6 - 6 - 5) * 256 - (5 - low) * 256 + i * 4,
                     4
@@ -260,8 +262,8 @@ fn apply_benes(r: &mut [u8; 1024], bits: &[u8; COND_BYTES], rev: usize) {
     let mut calc_index = if rev == 0 { 0 } else { 12288 };
 
     for (i, chunk) in r.chunks(16).enumerate() {
-        r_int_v[0][i] = util::load8(sub!(chunk, 0, 8));
-        r_int_v[1][i] = util::load8(sub!(chunk, 8, 8));
+        r_int_v[0][i] = u64::from_le_bytes(*sub!(chunk, 0, 8));
+        r_int_v[1][i] = u64::from_le_bytes(*sub!(chunk, 8, 8));
     }
 
     transpose::transpose(&mut r_int_h[0], r_int_v[0]);
@@ -269,7 +271,7 @@ fn apply_benes(r: &mut [u8; 1024], bits: &[u8; COND_BYTES], rev: usize) {
 
     for iter in 0..=6 {
         for (i, chunk) in bits[calc_index..(calc_index + 512)].chunks(8).enumerate() {
-            b_int_v[i] = util::load8(sub!(chunk, 0, 8));
+            b_int_v[i] = u64::from_le_bytes(*sub!(chunk, 0, 8));
         }
 
         calc_index = if rev == 0 {
@@ -288,7 +290,7 @@ fn apply_benes(r: &mut [u8; 1024], bits: &[u8; COND_BYTES], rev: usize) {
 
     for iter in 0..=5 {
         for (i, chunk) in bits[calc_index..(calc_index + 512)].chunks(8).enumerate() {
-            b_int_v[i] = util::load8(sub!(chunk, 0, 8));
+            b_int_v[i] = u64::from_le_bytes(*sub!(chunk, 0, 8));
         }
 
         calc_index = if rev == 0 {
@@ -302,7 +304,7 @@ fn apply_benes(r: &mut [u8; 1024], bits: &[u8; COND_BYTES], rev: usize) {
 
     for iter in (0..=4).rev() {
         for (i, chunk) in bits[calc_index..(calc_index + 512)].chunks(8).enumerate() {
-            b_int_v[i] = util::load8(sub!(chunk, 0, 8));
+            b_int_v[i] = u64::from_le_bytes(*sub!(chunk, 0, 8));
         }
         calc_index = if rev == 0 {
             calc_index + 512
@@ -318,7 +320,7 @@ fn apply_benes(r: &mut [u8; 1024], bits: &[u8; COND_BYTES], rev: usize) {
 
     for iter in (0..=6).rev() {
         for (i, chunk) in bits[calc_index..(calc_index + 512)].chunks(8).enumerate() {
-            b_int_v[i] = util::load8(sub!(chunk, 0, 8));
+            b_int_v[i] = u64::from_le_bytes(*sub!(chunk, 0, 8));
         }
         // NOTE the second condition prevents a trailing integer underflow
         //      (recognize that calc_index is not used after the last subtraction)

--- a/src/benes.rs
+++ b/src/benes.rs
@@ -184,7 +184,7 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
         transpose::transpose_64x64_inplace(&mut bs);
 
         for i in 0..64 {
-            util::store8(sub!(mut r, i * 8, 8), bs[i]);
+            *sub!(mut r, i * 8, 8) = bs[i].to_le_bytes();
         }
     } else {
         for i in 0..64 {
@@ -243,7 +243,7 @@ fn apply_benes(r: &mut [u8; 512], bits: &[u8; COND_BYTES], rev: usize) {
         transpose::transpose_64x64_inplace(&mut bs);
 
         for i in 0..64 {
-            util::store8(sub!(mut r, i * 8, 8), bs[i]);
+            *sub!(mut r, i * 8, 8) = bs[i].to_le_bytes();
         }
     }
 }
@@ -339,8 +339,8 @@ fn apply_benes(r: &mut [u8; 1024], bits: &[u8; COND_BYTES], rev: usize) {
     transpose::transpose(&mut r_int_v[1], r_int_h[1]);
 
     for (i, chunk) in r.chunks_mut(16).enumerate() {
-        util::store8(sub!(mut chunk, 0, 8), r_int_v[0][i]);
-        util::store8(sub!(mut chunk, 8, 8), r_int_v[1][i]);
+        *sub!(mut chunk, 0, 8) = r_int_v[0][i].to_le_bytes();
+        *sub!(mut chunk, 8, 8) = r_int_v[1][i].to_le_bytes();
     }
 }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -12,7 +12,7 @@ use crate::{
     params::{COND_BYTES, GFBITS, IRR_BYTES, SYND_BYTES, SYS_N, SYS_T},
     pk_gen::pk_gen,
     sk_gen::genpoly_gen,
-    util::{load_gf, store8, store_gf},
+    util::{load_gf, store_gf},
 };
 use rand::{CryptoRng, RngCore};
 
@@ -351,7 +351,7 @@ pub fn crypto_kem_keypair<R: CryptoRng + RngCore>(
             pivots = 0xFFFFFFFF;
         }
 
-        store8(sub!(mut sk, 32, 8), pivots);
+        *sub!(mut sk, 32, 8) = pivots.to_le_bytes();
 
         break;
     }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -12,7 +12,7 @@ use crate::{
     params::{COND_BYTES, GFBITS, IRR_BYTES, SYND_BYTES, SYS_N, SYS_T},
     pk_gen::pk_gen,
     sk_gen::genpoly_gen,
-    util::{load4, load_gf, store8, store_gf},
+    util::{load_gf, store8, store_gf},
 };
 use rand::{CryptoRng, RngCore};
 
@@ -292,7 +292,7 @@ pub fn crypto_kem_keypair<R: CryptoRng + RngCore>(
         // generating permutation
 
         for (i, chunk) in r[PERM..IRR_POLYS].chunks(4).enumerate() {
-            perm[i] = load4(sub!(chunk, 0, 4));
+            perm[i] = u32::from_le_bytes(*sub!(chunk, 0, 4));
         }
 
         #[cfg(any(

--- a/src/pk_gen.rs
+++ b/src/pk_gen.rs
@@ -16,7 +16,7 @@ use crate::{
     feature = "mceliece6960119f",
     feature = "mceliece8192128f"
 ))]
-use crate::util::{load8, store8};
+use crate::util::store8;
 
 /// Return number of trailing zeros of the non-zero input `input`
 #[cfg(any(
@@ -81,7 +81,7 @@ fn mov_columns(
 
     #[cfg(not(feature = "mceliece6960119f"))]
     for i in 0..32 {
-        buf[i] = load8(sub!(mat[row + i], block_idx, 8));
+        buf[i] = u64::from_le_bytes(*sub!(mat[row + i], block_idx, 8));
     }
 
     #[cfg(feature = "mceliece6960119f")]
@@ -93,7 +93,7 @@ fn mov_columns(
             tmp[j] = (tmp[j] >> tail) | (tmp[j + 1] << (8 - tail));
         }
 
-        buf[i] = load8(sub!(tmp, 0, 8));
+        buf[i] = u64::from_le_bytes(*sub!(tmp, 0, 8));
     }
 
     // Compute the column indices of pivots by Gaussian elimination.
@@ -141,7 +141,7 @@ fn mov_columns(
     // moving columns of mat according to the column indices of pivots
     #[cfg(not(feature = "mceliece6960119f"))]
     for i in 0..PK_NROWS {
-        let mut t = load8(sub!(mat[i], block_idx, 8));
+        let mut t = u64::from_le_bytes(*sub!(mat[i], block_idx, 8));
 
         for j in 0..32 {
             let mut d: u64 = t >> j;
@@ -164,7 +164,7 @@ fn mov_columns(
             tmp[k] = (tmp[k] >> tail) | (tmp[k + 1] << (8 - tail));
         }
 
-        let mut t = load8(sub!(tmp, 0, 8));
+        let mut t = u64::from_le_bytes(*sub!(tmp, 0, 8));
 
         for j in 0..32 {
             let mut d = t >> j;

--- a/src/pk_gen.rs
+++ b/src/pk_gen.rs
@@ -16,7 +16,6 @@ use crate::{
     feature = "mceliece6960119f",
     feature = "mceliece8192128f"
 ))]
-use crate::util::store8;
 
 /// Return number of trailing zeros of the non-zero input `input`
 #[cfg(any(
@@ -152,7 +151,7 @@ fn mov_columns(
             t ^= d << j;
         }
 
-        store8(sub!(mut mat[i], block_idx, 8), t);
+        *sub!(mut mat[i], block_idx, 8) = t.to_le_bytes();
     }
 
     #[cfg(feature = "mceliece6960119f")]
@@ -175,7 +174,7 @@ fn mov_columns(
             t ^= d << j;
         }
 
-        store8(sub!(mut tmp, 0, 8), t);
+        *sub!(mut tmp, 0, 8) = t.to_le_bytes();
 
         mat[i][block_idx + 8] = (mat[i][block_idx + 8] >> tail << tail) | (tmp[7] >> (8 - tail));
         mat[i][block_idx + 0] = (tmp[0] << tail) | (mat[i][block_idx] << (8 - tail) >> (8 - tail));

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,18 +19,6 @@ pub(crate) fn load_gf(src: &[u8; 2]) -> Gf {
     a & (GFMASK as u16)
 }
 
-/// Take `input` and store it in 8 bytes, `out` points to.
-pub(crate) fn store8(out: &mut [u8; 8], input: u64) {
-    out[0] = input.wrapping_shr(0x00) as u8;
-    out[1] = input.wrapping_shr(0x08) as u8;
-    out[2] = input.wrapping_shr(0x10) as u8;
-    out[3] = input.wrapping_shr(0x18) as u8;
-    out[4] = input.wrapping_shr(0x20) as u8;
-    out[5] = input.wrapping_shr(0x28) as u8;
-    out[6] = input.wrapping_shr(0x30) as u8;
-    out[7] = input.wrapping_shr(0x38) as u8;
-}
-
 /// Reverse the bits of Gf element `a`. The LSB becomes the MSB.
 /// The 2nd LSB becomes the 2nd MSB. etc …
 pub(crate) fn bitrev(mut a: Gf) -> Gf {

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,17 +19,6 @@ pub(crate) fn load_gf(src: &[u8; 2]) -> Gf {
     a & (GFMASK as u16)
 }
 
-/// Interpret 4 bytes from `src` as integer and return it as u32
-pub(crate) fn load4(input: &[u8; 4]) -> u32 {
-    let mut ret: u32 = input[3] as u32;
-
-    for i in (0..=2).rev() {
-        ret <<= 8;
-        ret |= input[i] as u32;
-    }
-    ret
-}
-
 /// Take `input` and store it in 8 bytes, `out` points to.
 pub(crate) fn store8(out: &mut [u8; 8], input: u64) {
     out[0] = input.wrapping_shr(0x00) as u8;
@@ -40,18 +29,6 @@ pub(crate) fn store8(out: &mut [u8; 8], input: u64) {
     out[5] = input.wrapping_shr(0x28) as u8;
     out[6] = input.wrapping_shr(0x30) as u8;
     out[7] = input.wrapping_shr(0x38) as u8;
-}
-
-/// Interpret 8 bytes from `input` as integer and return it as u64.
-pub(crate) fn load8(input: &[u8; 8]) -> u64 {
-    let mut ret: u64 = input[7] as u64;
-
-    for i in (0..=6).rev() {
-        ret <<= 8;
-        ret |= input[i] as u64;
-    }
-
-    ret
 }
 
 /// Reverse the bits of Gf element `a`. The LSB becomes the MSB.

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,20 +3,15 @@
 use crate::{gf::Gf, params::GFMASK};
 
 /// Store Gf element `a` in array `dest`
-pub(crate) fn store_gf(dest: &mut [u8; 2], a: Gf) {
-    dest[0] = (a & 0xFF) as u8;
-    dest[1] = a.overflowing_shr(8).0 as u8;
+#[inline(always)]
+pub(crate) fn store_gf(dest: &mut [u8; 2], gf: Gf) {
+    *dest = gf.to_le_bytes();
 }
 
 /// Interpret 2 bytes from `src` as integer and return it as Gf element
+#[inline(always)]
 pub(crate) fn load_gf(src: &[u8; 2]) -> Gf {
-    let mut a: u16;
-
-    a = src[1] as u16;
-    a <<= 8;
-    a |= src[0] as u16;
-
-    a & (GFMASK as u16)
+    u16::from_le_bytes(*src) & (GFMASK as u16)
 }
 
 /// Reverse the bits of Gf element `a`. The LSB becomes the MSB.


### PR DESCRIPTION
I found that the `util` module contains a bunch of bit shifting code that has equivalents in the standard library. The standard library versions probably compile to more optimized code, and this crate does not have to take responsibility for the correctness. I find that this change makes the code easier to read, and less likely to introduce errors.

I could also see a performance improvement thanks to this. When I ran the benchmarks locally on my computer the `kem_enc` benchmark reports this:
```
kem_enc                 time:   [238068.6381 cycles 243812.5489 cycles 249344.6288 cycles]
                        change: [-9.6026% -7.2295% -4.5918%] (p = 0.00 < 0.05)
                        Performance has improved.
```
:partying_face: 