### PR TITLE
Improve readme examples, split them up

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,47 +45,43 @@ To use a specific Classic McEliece variant, you need to import it with the corre
 classic-mceliece-rust = { version = "1.0", features = ["mceliece6960119"] }
 ```
 
-The `simple` example illustrates the API:
+If you have access to `alloc` (you are not on `no_std`), then the simplest and most ergonomic
+way of using the library is with heap allocated keys and the `*_boxed` helper methods:
 ```rust
-use classic_mceliece_rust::{keypair, encapsulate, decapsulate};
-#[cfg(feature = "alloc")]
-use classic_mceliece_rust::keypair_boxed;
-use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
+#![cfg(feature = "alloc")]
+use classic_mceliece_rust::{keypair_boxed, encapsulate_boxed, decapsulate_boxed};
 
 fn main()  {
     let mut rng = rand::thread_rng();
 
-    // since the public keys in Classic McEliece are rather large, we provide
-    // multiple ways to store the keys. On the stack or the heap (heap requires alloc)
+    // Alice computes the keypair
+    let (public_key, secret_key) = keypair_boxed(&mut rng);
 
-    // option one: pass a reference to buffers to `keypair`
-    // the key objects then only reference the buffers and do not own them.
-    // See [Stack usage] below
-    {
-        // This buffer, `pk_buf`, takes up a lot of stack space
-        let mut pk_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
-        let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
-        let (public_key, secret_key) = keypair(&mut pk_buf, &mut sk_buf, &mut rng);
-        // Does not compile, lifetime are not 'static
-        // std::thread::spawn(move || drop((public_key, secret_key)));
-    }
+    // Send `secret_key` over to Bob.
+    // Bob computes the shared secret and a ciphertext
+    let (ciphertext, shared_secret_bob) = encapsulate_boxed(&public_key, &mut rng);
 
-    // Option two: Pass the ownership of an array on the heap. This requires the `alloc` feature.
-    #[cfg(feature = "alloc")]
-    {
-        let heap_pk_buf = Box::new([0u8; CRYPTO_PUBLICKEYBYTES]);
-        let heap_sk_buf = Box::new([0u8; CRYPTO_SECRETKEYBYTES]);
-        let (public_key, secret_key) = keypair(heap_pk_buf, heap_sk_buf, &mut rng);
-        std::thread::spawn(move || drop((public_key, secret_key)));
+    // Send `ciphertext` back to Alice.
+    // Alice decapsulates the ciphertext...
+    let shared_secret_alice = decapsulate_boxed(&ciphertext, &secret_key);
 
-        // there is even a helper function for this
-        let (public_key, secret_key) = keypair_boxed(&mut rng);
-        std::thread::spawn(move || drop((public_key, secret_key)));
-    }
+    // ... and ends up with the same key material as Bob.
+    assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
+}
+```
 
-    // Let's use option one here. Mostly so this test won't depend on the alloc feature.
-    // But if you have alloc you probably want to store the public key on the heap
-    // since it's so large!
+You can also use this crate in a `no_std` environment. Then you don't have access to boxed
+keys and you need to provide the kem functions with the storage they should use.
+You can store the key material directly on the stack. However, see the stack usage section
+further down for known issues with this.
+```rust
+use classic_mceliece_rust::{keypair, encapsulate, decapsulate};
+use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
+
+fn main()  {
+    let mut rng = rand::thread_rng();
+
+    // Please mind that `public_key_buf` is very large.
     let mut public_key_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
     let mut secret_key_buf = [0u8; CRYPTO_SECRETKEYBYTES];
     let (public_key, secret_key) = keypair(&mut public_key_buf, &mut secret_key_buf, &mut rng);

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ classic-mceliece-rust = { version = "1.0", features = ["mceliece6960119"] }
 If you have access to `alloc` (you are not on `no_std`), then the simplest and most ergonomic
 way of using the library is with heap allocated keys and the `*_boxed` helper methods:
 ```rust
-#![cfg(feature = "alloc")]
-use classic_mceliece_rust::{keypair_boxed, encapsulate_boxed, decapsulate_boxed};
+#[cfg(feature = "alloc")] {
+    use classic_mceliece_rust::{keypair_boxed, encapsulate_boxed, decapsulate_boxed};
 
-fn main()  {
     let mut rng = rand::thread_rng();
 
     // Alice computes the keypair
@@ -78,22 +77,20 @@ further down for known issues with this.
 use classic_mceliece_rust::{keypair, encapsulate, decapsulate};
 use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
-fn main()  {
-    let mut rng = rand::thread_rng();
+let mut rng = rand::thread_rng();
 
-    // Please mind that `public_key_buf` is very large.
-    let mut public_key_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
-    let mut secret_key_buf = [0u8; CRYPTO_SECRETKEYBYTES];
-    let (public_key, secret_key) = keypair(&mut public_key_buf, &mut secret_key_buf, &mut rng);
+// Please mind that `public_key_buf` is very large.
+let mut public_key_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
+let mut secret_key_buf = [0u8; CRYPTO_SECRETKEYBYTES];
+let (public_key, secret_key) = keypair(&mut public_key_buf, &mut secret_key_buf, &mut rng);
 
-    let mut shared_secret_bob_buf = [0u8; CRYPTO_BYTES];
-    let (ciphertext, shared_secret_bob) = encapsulate(&public_key, &mut shared_secret_bob_buf, &mut rng);
+let mut shared_secret_bob_buf = [0u8; CRYPTO_BYTES];
+let (ciphertext, shared_secret_bob) = encapsulate(&public_key, &mut shared_secret_bob_buf, &mut rng);
 
-    let mut shared_secret_alice_buf = [0u8; CRYPTO_BYTES];
-    let shared_secret_alice = decapsulate(&ciphertext, &secret_key, &mut shared_secret_alice_buf);
+let mut shared_secret_alice_buf = [0u8; CRYPTO_BYTES];
+let shared_secret_alice = decapsulate(&ciphertext, &secret_key, &mut shared_secret_alice_buf);
 
-    assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
-}
+assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
 ```
 
 #### Stack usage
@@ -132,32 +129,30 @@ get it from the `as_array` method.
 use classic_mceliece_rust::keypair;
 use classic_mceliece_rust::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
-fn main()  {
-    let mut rng = rand::thread_rng();
+let mut rng = rand::thread_rng();
 
-    let mut pk_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
-    // Initialize to non-zero to show that it has been set to zero by the drop later
-    let mut sk_buf = [255u8; CRYPTO_SECRETKEYBYTES];
+let mut pk_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
+// Initialize to non-zero to show that it has been set to zero by the drop later
+let mut sk_buf = [255u8; CRYPTO_SECRETKEYBYTES];
 
-    // This is the WRONG way of accessing your keys. The buffer will
-    // be cleared once the `PrivateKey` returned from `keypair` goes out of scope.
-    // You should not rely on that array for anything except providing a temporary storage
-    // location to this library.
-    #[cfg(feature = "zeroize")]
-    {
-        let (_, secret_key) = keypair(&mut pk_buf, &mut sk_buf, &mut rng);
-        drop(secret_key);
-        // Ouch! The array only has zeroes now.
-        assert_eq!(sk_buf, [0; CRYPTO_SECRETKEYBYTES]);
-    }
+// This is the WRONG way of accessing your keys. The buffer will
+// be cleared once the `PrivateKey` returned from `keypair` goes out of scope.
+// You should not rely on that array for anything except providing a temporary storage
+// location to this library.
+#[cfg(feature = "zeroize")]
+{
+    let (_, secret_key) = keypair(&mut pk_buf, &mut sk_buf, &mut rng);
+    drop(secret_key);
+    // Ouch! The array only has zeroes now.
+    assert_eq!(sk_buf, [0; CRYPTO_SECRETKEYBYTES]);
+}
 
-    // Correct way of getting the secret key bytes if you do need them. However,
-    // if you want the secrets to stay secret, you should try to not read them out of their
-    // storage at all
-    {
-        let (_, secret_key) = keypair(&mut pk_buf, &mut sk_buf, &mut rng);
-        assert_ne!(secret_key.as_array(), &[0; CRYPTO_SECRETKEYBYTES]);
-    }
+// Correct way of getting the secret key bytes if you do need them. However,
+// if you want the secrets to stay secret, you should try to not read them out of their
+// storage at all
+{
+    let (_, secret_key) = keypair(&mut pk_buf, &mut sk_buf, &mut rng);
+    assert_ne!(secret_key.as_array(), &[0; CRYPTO_SECRETKEYBYTES]);
 }
 ```
 


### PR DESCRIPTION
The documentation examples did not run on Windows. And it was messy! It was a single huge example trying to show all ways of using the crate. I think this is way more structured!