### PR TITLE
Implement to_owned on all key types that has a lifetime, and avoid using the stack in the boxed functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,9 @@ enum KeyBuffer<'a, const SIZE: usize> {
 impl<'a, const SIZE: usize> KeyBuffer<'a, SIZE> {
     #[cfg(feature = "alloc")]
     fn to_owned(&self) -> KeyBuffer<'static, SIZE> {
-        KeyBuffer::Owned(Box::new(*self.as_ref()))
+        let mut new_buffer = KeyBuffer::Owned(util::alloc_boxed_array::<SIZE>());
+        new_buffer.as_mut().copy_from_slice(self.as_ref());
+        new_buffer
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,16 +78,10 @@ enum KeyBuffer<'a, const SIZE: usize> {
     Owned(Box<[u8; SIZE]>),
 }
 
-impl<'a, const SIZE: usize> From<&'a mut [u8; SIZE]> for KeyBuffer<'a, SIZE> {
-    fn from(buf: &'a mut [u8; SIZE]) -> Self {
-        Self::Borrowed(buf)
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<const SIZE: usize> From<Box<[u8; SIZE]>> for KeyBuffer<'static, SIZE> {
-    fn from(buf: Box<[u8; SIZE]>) -> Self {
-        Self::Owned(buf)
+impl<'a, const SIZE: usize> KeyBuffer<'a, SIZE> {
+    #[cfg(feature = "alloc")]
+    fn to_owned(&self) -> KeyBuffer<'static, SIZE> {
+        KeyBuffer::Owned(Box::new(*self.as_ref()))
     }
 }
 
@@ -128,11 +122,11 @@ impl<'a, const SIZE: usize> zeroize::Zeroize for KeyBuffer<'a, SIZE> {
 pub struct PublicKey<'a>(KeyBuffer<'a, CRYPTO_PUBLICKEYBYTES>);
 
 impl<'a> PublicKey<'a> {
-    /// Move the key to the heap and make it `'static`
+    /// Copies the key to the heap and makes it `'static`.
     #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     #[cfg(feature = "alloc")]
     pub fn to_owned(&self) -> PublicKey<'static> {
-        PublicKey(KeyBuffer::Owned(Box::new(*self.0.as_ref())))
+        PublicKey(self.0.to_owned())
     }
 
     pub fn as_array(&self) -> &[u8; CRYPTO_PUBLICKEYBYTES] {
@@ -153,6 +147,13 @@ impl<'a> AsRef<[u8]> for PublicKey<'a> {
 pub struct SecretKey<'a>(KeyBuffer<'a, CRYPTO_SECRETKEYBYTES>);
 
 impl<'a> SecretKey<'a> {
+    /// Copies the key to the heap and makes it `'static`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn to_owned(&self) -> SecretKey<'static> {
+        SecretKey(self.0.to_owned())
+    }
+
     pub fn as_array(&self) -> &[u8; CRYPTO_SECRETKEYBYTES] {
         self.0.as_ref()
     }
@@ -211,6 +212,13 @@ impl AsRef<[u8]> for Ciphertext {
 pub struct SharedSecret<'a>(KeyBuffer<'a, CRYPTO_BYTES>);
 
 impl<'a> SharedSecret<'a> {
+    /// Copies the secret to the heap and makes it `'static`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    #[cfg(feature = "alloc")]
+    pub fn to_owned(&self) -> SharedSecret<'static> {
+        SharedSecret(self.0.to_owned())
+    }
+
     pub fn as_array(&self) -> &[u8; CRYPTO_BYTES] {
         self.0.as_ref()
     }
@@ -260,8 +268,8 @@ pub fn keypair<'public, 'secret, R: CryptoRng + RngCore>(
     secret_key_buf: &'secret mut [u8; CRYPTO_SECRETKEYBYTES],
     rng: &mut R,
 ) -> (PublicKey<'public>, SecretKey<'secret>) {
-    let mut public_key_buf = KeyBuffer::from(public_key_buf);
-    let mut secret_key_buf = KeyBuffer::from(secret_key_buf);
+    let mut public_key_buf = KeyBuffer::Borrowed(public_key_buf);
+    let mut secret_key_buf = KeyBuffer::Borrowed(secret_key_buf);
 
     operations::crypto_kem_keypair(public_key_buf.as_mut(), secret_key_buf.as_mut(), rng);
 
@@ -275,8 +283,8 @@ pub fn keypair<'public, 'secret, R: CryptoRng + RngCore>(
 pub fn keypair_boxed<R: CryptoRng + RngCore>(
     rng: &mut R,
 ) -> (PublicKey<'static>, SecretKey<'static>) {
-    let mut public_key_buf = KeyBuffer::from(Box::new([0u8; CRYPTO_PUBLICKEYBYTES]));
-    let mut secret_key_buf = KeyBuffer::from(Box::new([0u8; CRYPTO_SECRETKEYBYTES]));
+    let mut public_key_buf = KeyBuffer::Owned(util::alloc_boxed_array::<CRYPTO_PUBLICKEYBYTES>());
+    let mut secret_key_buf = KeyBuffer::Owned(util::alloc_boxed_array::<CRYPTO_SECRETKEYBYTES>());
 
     operations::crypto_kem_keypair(public_key_buf.as_mut(), secret_key_buf.as_mut(), rng);
 
@@ -294,7 +302,7 @@ pub fn encapsulate<'shared_secret, R: CryptoRng + RngCore>(
     shared_secret_buf: &'shared_secret mut [u8; CRYPTO_BYTES],
     rng: &mut R,
 ) -> (Ciphertext, SharedSecret<'shared_secret>) {
-    let mut shared_secret_buf = KeyBuffer::from(shared_secret_buf);
+    let mut shared_secret_buf = KeyBuffer::Borrowed(shared_secret_buf);
     let mut ciphertext_buf = [0u8; CRYPTO_CIPHERTEXTBYTES];
 
     operations::crypto_kem_enc(
@@ -315,7 +323,7 @@ pub fn encapsulate_boxed<R: CryptoRng + RngCore>(
     public_key: &PublicKey<'_>,
     rng: &mut R,
 ) -> (Ciphertext, SharedSecret<'static>) {
-    let mut shared_secret_buf = KeyBuffer::from(Box::new([0u8; CRYPTO_BYTES]));
+    let mut shared_secret_buf = KeyBuffer::Owned(Box::new([0u8; CRYPTO_BYTES]));
     let mut ciphertext_buf = [0u8; CRYPTO_CIPHERTEXTBYTES];
 
     operations::crypto_kem_enc(
@@ -337,7 +345,7 @@ pub fn decapsulate<'shared_secret>(
     secret_key: &SecretKey,
     shared_secret_buf: &'shared_secret mut [u8; CRYPTO_BYTES],
 ) -> SharedSecret<'shared_secret> {
-    let mut shared_secret_buf = KeyBuffer::from(shared_secret_buf);
+    let mut shared_secret_buf = KeyBuffer::Borrowed(shared_secret_buf);
 
     operations::crypto_kem_dec(
         shared_secret_buf.as_mut(),
@@ -353,7 +361,7 @@ pub fn decapsulate<'shared_secret>(
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn decapsulate_boxed(ciphertext: &Ciphertext, secret_key: &SecretKey) -> SharedSecret<'static> {
-    let mut shared_secret_buf = KeyBuffer::from(Box::new([0u8; CRYPTO_BYTES]));
+    let mut shared_secret_buf = KeyBuffer::Owned(Box::new([0u8; CRYPTO_BYTES]));
 
     operations::crypto_kem_dec(
         shared_secret_buf.as_mut(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -32,6 +32,14 @@ pub(crate) fn bitrev(mut a: Gf) -> Gf {
     }
 }
 
+/// Ugly hack to allocate a `Box<[u8; _]>` directly on the heap without first
+/// putting the array on the stack
+#[cfg(feature = "alloc")]
+#[inline(always)]
+pub fn alloc_boxed_array<const SIZE: usize>() -> alloc::boxed::Box<[u8; SIZE]> {
+    alloc::boxed::Box::<[u8; SIZE]>::try_from(alloc::vec![0u8; SIZE].into_boxed_slice()).unwrap()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -1,0 +1,89 @@
+#![cfg(feature = "alloc")]
+
+use classic_mceliece_rust::{decapsulate_boxed, encapsulate_boxed, keypair, keypair_boxed};
+use classic_mceliece_rust::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
+use std::thread;
+
+/// The smallest amount of stack needed to reliably run the KEM from this library.
+const MIN_STACK_SIZE_FOR_THIS_CRATE: usize = (CRYPTO_PUBLICKEYBYTES as f32 * 1.65) as usize;
+
+#[test]
+fn to_owned() {
+    fn run() {
+        let mut rng = rand::thread_rng();
+
+        let mut pk_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
+        let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
+        let (_, secret_key) = keypair(&mut pk_buf, &mut sk_buf, &mut rng);
+
+        let secret_key_data = *secret_key.as_array();
+
+        let owned_secret_key = secret_key.to_owned();
+        // Make sure the correct data got transferred to the owned variant
+        // and that the original was not modified.
+        assert_eq!(owned_secret_key.as_array(), &secret_key_data);
+        assert_eq!(secret_key.as_array(), &secret_key_data);
+
+        // Make sure the owned version does not get zeroized when the source it was
+        // created from goes out of scope.
+        drop(secret_key);
+        assert_ne!(owned_secret_key.as_array(), &[0; CRYPTO_SECRETKEYBYTES]);
+
+        // Verify that the zeroize feature correctly zeroes out the backing buffer when the feature is
+        // active, otherwise not.
+        #[cfg(feature = "zeroize")]
+        {
+            assert_eq!(sk_buf, [0; CRYPTO_SECRETKEYBYTES]);
+        }
+        #[cfg(not(feature = "zeroize"))]
+        {
+            assert_eq!(sk_buf, secret_key_data);
+        }
+    }
+
+    thread::Builder::new()
+        // Use a large enough stack size to run all kem variants with the key buffers on the stack.
+        .stack_size(4 * 1024 * 1024)
+        .spawn(run)
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+#[test]
+fn boxed_versions_dont_trash_the_stack() {
+    fn run() {
+        let mut rng = rand::thread_rng();
+
+        let (public_key, secret_key) = keypair_boxed(&mut rng);
+        let (ciphertext, shared_secret_bob) = encapsulate_boxed(&public_key, &mut rng);
+        let shared_secret_alice = decapsulate_boxed(&ciphertext, &secret_key);
+        assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
+    }
+
+    thread::Builder::new()
+        .stack_size(MIN_STACK_SIZE_FOR_THIS_CRATE)
+        .spawn(run)
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+#[test]
+fn to_owned_not_copying_to_stack() {
+    fn run_kem() {
+        let mut rng = rand::thread_rng();
+
+        let (public_key, _) = keypair_boxed(&mut rng);
+
+        let owned_public_key = public_key.to_owned();
+        assert_eq!(public_key.as_array(), owned_public_key.as_array());
+    }
+
+    thread::Builder::new()
+        .stack_size(MIN_STACK_SIZE_FOR_THIS_CRATE)
+        .spawn(run_kem)
+        .unwrap()
+        .join()
+        .unwrap();
+}

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -80,7 +80,8 @@ fn to_owned_not_copying_to_stack() {
     };
 
     thread::Builder::new()
-        .stack_size(512 * 1024)
+        // Force to_owned to run with a tiny stack.
+        .stack_size(16 * 1024)
         .spawn(run)
         .unwrap()
         .join()

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -5,7 +5,7 @@ use classic_mceliece_rust::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 use std::thread;
 
 /// The smallest amount of stack needed to reliably run the KEM from this library.
-const MIN_STACK_SIZE_FOR_THIS_CRATE: usize = (CRYPTO_PUBLICKEYBYTES as f32 * 1.65) as usize;
+const MIN_STACK_SIZE_FOR_THIS_CRATE: usize = (CRYPTO_PUBLICKEYBYTES as f32 * 1.8) as usize;
 
 #[test]
 fn to_owned() {


### PR DESCRIPTION
We only had `to_owned` on the `PublicKey`. There might be reasons why people want `'static` versions of the `SecretKey` and `SharedSecret` as well. So let's implement that.

I also added tests for these conversions.