### PR TITLE
Fix build errors in benchmarks, and make CI not fail on Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,12 @@ jobs:
           command: test
           args: --features mceliece8192128f
 
+      - name: Compile benchmarks
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --benches
+
       - name: Test kem feature
         uses: actions-rs/cargo@v1
         with:

--- a/README.md
+++ b/README.md
@@ -51,21 +51,31 @@ way of using the library is with heap allocated keys and the `*_boxed` helper me
 #[cfg(feature = "alloc")] {
     use classic_mceliece_rust::{keypair_boxed, encapsulate_boxed, decapsulate_boxed};
 
-    let mut rng = rand::thread_rng();
+    fn run_kem() {
+        let mut rng = rand::thread_rng();
 
-    // Alice computes the keypair
-    let (public_key, secret_key) = keypair_boxed(&mut rng);
+        // Alice computes the keypair
+        let (public_key, secret_key) = keypair_boxed(&mut rng);
 
-    // Send `secret_key` over to Bob.
-    // Bob computes the shared secret and a ciphertext
-    let (ciphertext, shared_secret_bob) = encapsulate_boxed(&public_key, &mut rng);
+        // Send `secret_key` over to Bob.
+        // Bob computes the shared secret and a ciphertext
+        let (ciphertext, shared_secret_bob) = encapsulate_boxed(&public_key, &mut rng);
 
-    // Send `ciphertext` back to Alice.
-    // Alice decapsulates the ciphertext...
-    let shared_secret_alice = decapsulate_boxed(&ciphertext, &secret_key);
+        // Send `ciphertext` back to Alice.
+        // Alice decapsulates the ciphertext...
+        let shared_secret_alice = decapsulate_boxed(&ciphertext, &secret_key);
 
-    // ... and ends up with the same key material as Bob.
-    assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
+        // ... and ends up with the same key material as Bob.
+        assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
+    }
+
+    std::thread::Builder::new()
+        // This library needs quite a lot of stack space to work
+        .stack_size(2 * 1024 * 1024)
+        .spawn(run_kem)
+        .unwrap()
+        .join()
+        .unwrap();
 }
 ```
 

--- a/benches/kem_api.rs
+++ b/benches/kem_api.rs
@@ -39,11 +39,11 @@ pub fn bench_kem_keypair(criterion: &mut Criterion<CyclesPerByte>) {
 
 pub fn bench_kem_enc(criterion: &mut Criterion<CyclesPerByte>) {
     let mut rng = rand::thread_rng();
-    let pk_buf = Box::new([0u8; CRYPTO_PUBLICKEYBYTES]);
+    let mut pk_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
     let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut ss_buf = [0u8; CRYPTO_BYTES];
 
-    let (pk, _) = keypair(pk_buf, &mut sk_buf, &mut rng);
+    let (pk, _) = keypair(&mut pk_buf, &mut sk_buf, &mut rng);
 
     criterion.bench_function("kem_enc", |b| {
         b.iter(|| {


### PR DESCRIPTION
I found that the benchmarks did not compile after the changes that was recently merged.. The CI does not verify if the benchmarks still work. So I fixed both of those things here.