### PR TITLE
Hotfix/fix rust clippy warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -144,3 +144,17 @@ jobs:
         run: cargo doc --no-deps --features kem
         env:
           RUSTDOCFLAGS: "--cfg docsrs --deny warnings"
+
+  # Test the generated KAT files against known hashes 
+  kat-tests:
+    name: Full KAT tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: KATKEMS
+        run: bash tests/katkem.sh

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,16 +145,3 @@ jobs:
         env:
           RUSTDOCFLAGS: "--cfg docsrs --deny warnings"
 
-  # Test the generated KAT files against known hashes 
-  kat-tests:
-    name: Full KAT tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: KATKEMS
-        run: bash tests/katkem.sh

--- a/.github/workflows/kat_tests.yaml
+++ b/.github/workflows/kat_tests.yaml
@@ -1,0 +1,20 @@
+on: 
+  workflow_dispatch
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Test the generated KAT files against known hashes 
+  kat-tests:
+    name: Full KAT tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: KATKEMS
+        run: bash tests/katkem.sh

--- a/examples/katkem.rs
+++ b/examples/katkem.rs
@@ -74,7 +74,7 @@ impl Testcase {
 
     fn write_to_file(&self, fd: &mut fs::File) -> R {
         let repr_bytes = |bytes: &[u8]| -> String {
-            if is_zero(&bytes) {
+            if is_zero(bytes) {
                 "".to_string()
             } else {
                 format!(" {}", hex::encode_upper(bytes))
@@ -106,12 +106,12 @@ impl Testcase {
             return Ok(false);
         }
 
-        let mut fields = line.split("=");
-        let name = match fields.nth(0) {
+        let mut fields = line.split('=');
+        let name = match fields.next() {
             Some(n) => n.trim(),
             None => return err("could not split key with '=' assignment operator"),
         };
-        let value = match fields.nth(0) {
+        let value = match fields.next() {
             Some(v) => v.trim(),
             None => return err("could not split value with '=' assignment operator"),
         };
@@ -148,7 +148,7 @@ impl fmt::Display for Testcase {
         //   to abstract Testcase.write_to_file(…) for stdout AND files.
         //   As a result, I decided to duplicate the code.
         let repr_bytes = |bytes: &[u8]| -> String {
-            if is_zero(&bytes) {
+            if is_zero(bytes) {
                 "".to_string()
             } else {
                 format!(" {}", hex::encode_upper(bytes))
@@ -169,8 +169,8 @@ fn create_request_file(filepath: &str) -> R {
 
     // initialize RNG
     let mut entropy_input = [0u8; 48];
-    for i in 0..48 {
-        entropy_input[i] = i as u8;
+    for (i, e) in entropy_input.iter_mut().enumerate() {
+        *e = i as u8;
     }
     let mut rng = AesState::new();
     rng.randombytes_init(entropy_input);
@@ -193,8 +193,8 @@ fn create_response_file(filepath: &str) -> R {
 
     // initialize RNG
     let mut entropy_input = [0u8; 48];
-    for i in 0..48 {
-        entropy_input[i] = i as u8;
+    for (i, e) in entropy_input.iter_mut().enumerate() {
+        *e = i as u8;
     }
     let mut rng = AesState::new();
     rng.randombytes_init(entropy_input);

--- a/src/benes.rs
+++ b/src/benes.rs
@@ -398,11 +398,11 @@ mod tests {
     fn test_layer() {
         let mut data = [0u64; 64];
         let mut bits = [0u64; 32];
-        for i in 0..64 {
-            data[i] = 0xAAAA ^ (i as u64 * 17);
+        for (i, d) in data.iter_mut().enumerate() {
+            *d = 0xAAAA ^ (i as u64 * 17);
         }
-        for i in 0..32 {
-            bits[i] = (i as u64) << 3;
+        for (i, d) in bits.iter_mut().enumerate() {
+            *d = (i as u64) << 3;
         }
         layer(&mut data, &bits, 4);
         assert_eq!(

--- a/src/benes.rs
+++ b/src/benes.rs
@@ -30,11 +30,11 @@ fn layer(data: &mut [u64], bits: &[u64], lgs: usize) {
     let mut i = 0usize;
     while i < 64 {
         for j in i..(i + s) {
-            let mut d = data[j + 0] ^ data[j + s];
+            let mut d = data[j] ^ data[j + s];
             d &= bits[index];
             index += 1;
 
-            data[j + 0] ^= d;
+            data[j] ^= d;
             data[j + s] ^= d;
         }
         i += s * 2;
@@ -351,27 +351,26 @@ pub(crate) fn support_gen(s: &mut [Gf; SYS_N], c: &[u8; COND_BYTES]) {
     for i in 0..(1 << GFBITS) {
         a = util::bitrev(i as Gf);
 
-        for j in 0..GFBITS {
-            l[j][i / 8] |= (((a >> j) & 1) << (i % 8)) as u8;
+        for (j, itr_l) in l.iter_mut().enumerate().take(GFBITS) {
+            itr_l[i / 8] |= (((a >> j) & 1) << (i % 8)) as u8;
         }
     }
 
-    for j in 0..GFBITS {
+    for itr_l in l.iter_mut().take(GFBITS) {
         #[cfg(any(feature = "mceliece348864", feature = "mceliece348864f"))]
         {
-            apply_benes(&mut l[j], c, 0);
+            apply_benes(itr_l, c, 0);
         }
         #[cfg(not(any(feature = "mceliece348864", feature = "mceliece348864f")))]
         {
-            apply_benes(&mut l[j], c, 0);
+            apply_benes(itr_l, c, 0);
         }
     }
 
-    for i in 0..SYS_N {
-        s[i] = 0;
+    for (i, itr_s) in s.iter_mut().enumerate().take(SYS_N) {
         for j in (0..=(GFBITS - 1)).rev() {
-            s[i] <<= 1;
-            s[i] |= ((l[j][i / 8] >> (i % 8)) & 1) as u16;
+            *itr_s <<= 1;
+            *itr_s |= ((l[j][i / 8] >> (i % 8)) & 1) as u16;
         }
     }
 }

--- a/src/benes.rs
+++ b/src/benes.rs
@@ -351,12 +351,12 @@ pub(crate) fn support_gen(s: &mut [Gf; SYS_N], c: &[u8; COND_BYTES]) {
     for i in 0..(1 << GFBITS) {
         a = util::bitrev(i as Gf);
 
-        for (j, itr_l) in l.iter_mut().enumerate().take(GFBITS) {
+        for (j, itr_l) in l.iter_mut().enumerate() {
             itr_l[i / 8] |= (((a >> j) & 1) << (i % 8)) as u8;
         }
     }
 
-    for itr_l in l.iter_mut().take(GFBITS) {
+    for itr_l in l.iter_mut() {
         #[cfg(any(feature = "mceliece348864", feature = "mceliece348864f"))]
         {
             apply_benes(itr_l, c, 0);
@@ -367,7 +367,8 @@ pub(crate) fn support_gen(s: &mut [Gf; SYS_N], c: &[u8; COND_BYTES]) {
         }
     }
 
-    for (i, itr_s) in s.iter_mut().enumerate().take(SYS_N) {
+    for (i, itr_s) in s.iter_mut().enumerate() {
+        *itr_s = 0;
         for j in (0..=(GFBITS - 1)).rev() {
             *itr_s <<= 1;
             *itr_s |= ((l[j][i / 8] >> (i % 8)) & 1) as u16;

--- a/src/bm.rs
+++ b/src/bm.rs
@@ -44,9 +44,7 @@ pub(crate) fn bm(out: &mut [Gf; SYS_T + 1], s: &mut [Gf; 2 * SYS_T]) {
         mle = mle.wrapping_sub(1);
         mle &= mne;
 
-        for i in 0..=SYS_T {
-            t[i] = c[i];
-        }
+        t[..(SYS_T + 1)].copy_from_slice(&c[..(SYS_T + 1)]);
 
         let f: Gf = gf_frac(base, d);
 

--- a/src/bm.rs
+++ b/src/bm.rs
@@ -19,7 +19,7 @@ pub(crate) fn bm(out: &mut [Gf; SYS_T + 1], s: &mut [Gf; 2 * SYS_T]) {
     let mut mle: u16;
     let mut mne: u16;
 
-    let mut t = [0u16; SYS_T + 1];
+    let mut t;
     let mut c = [0u16; SYS_T + 1];
     let mut b = [0u16; SYS_T + 1];
 
@@ -44,7 +44,7 @@ pub(crate) fn bm(out: &mut [Gf; SYS_T + 1], s: &mut [Gf; 2 * SYS_T]) {
         mle = mle.wrapping_sub(1);
         mle &= mne;
 
-        t[..(SYS_T + 1)].copy_from_slice(&c[..(SYS_T + 1)]);
+        t = c;
 
         let f: Gf = gf_frac(base, d);
 

--- a/src/controlbits.rs
+++ b/src/controlbits.rs
@@ -115,8 +115,8 @@ fn cbrecursion(
     }
     /* B = (p<<16)+c */
 
-    for x in 0..n {
-        temp[x] = (temp[x] << 16) | (x as i32); /* A = (pibar<<16)+id */
+    for (x, itr_temp) in temp.iter_mut().enumerate().take(n) {
+        *itr_temp = (*itr_temp << 16) | (x as i32); /* A = (pibar<<16)+id */
     }
     int32_sort(&mut temp[0..n]); /* A = (id<<16)+pibar^-1 */
 
@@ -306,8 +306,11 @@ pub(crate) fn controlbitsfrompermutation(out: &mut [u8], pi: &[i16], w: usize, n
         cbrecursion(sub, 0, 1, 0, w, n, &mut temp, &pi_as_i32);
 
         let mut pi_test = [0i16; 1 << GFBITS];
-        for i in 0..n {
+        /*for i in 0..n {
             pi_test[i] = i as i16;
+        }*/
+        for (i, itr_pi_test) in pi_test.iter_mut().enumerate().take(n) {
+            *itr_pi_test = i as i16;
         }
 
         for i in 0..w as usize {

--- a/src/controlbits.rs
+++ b/src/controlbits.rs
@@ -63,6 +63,7 @@ fn layer(p: &mut [i16], cb: &[u8], s: i32, n: i32) {
 ///
 /// But the following descriptions still hold true:
 ///   out is filled with (2m-1)n/2 control bits at positions pos, pos+step, …
+#[allow(clippy::too_many_arguments)]
 fn cbrecursion(
     out: &mut [u8],
     mut pos: usize,

--- a/src/controlbits.rs
+++ b/src/controlbits.rs
@@ -307,10 +307,8 @@ pub(crate) fn controlbitsfrompermutation(out: &mut [u8], pi: &[i16], w: usize, n
         cbrecursion(sub, 0, 1, 0, w, n, &mut temp, &pi_as_i32);
 
         let mut pi_test = [0i16; 1 << GFBITS];
-        /*for i in 0..n {
-            pi_test[i] = i as i16;
-        }*/
-        for (i, itr_pi_test) in pi_test.iter_mut().enumerate().take(n) {
+
+        for (i, itr_pi_test) in pi_test.iter_mut().enumerate() {
             *itr_pi_test = i as i16;
         }
 

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -33,9 +33,7 @@ pub(crate) fn decrypt(
     let mut locator = [0u16; SYS_T + 1];
     let mut images = [0u16; SYS_N];
 
-    for i in 0..SYND_BYTES {
-        r[i] = c[i];
-    }
+    r[..SYND_BYTES].copy_from_slice(&c[..SYND_BYTES]);
 
     r[SYND_BYTES..SYS_N / 8].fill(0);
 
@@ -46,11 +44,11 @@ pub(crate) fn decrypt(
 
     support_gen(&mut l, sub!(sk, IRR_BYTES, COND_BYTES));
 
-    synd(&mut s, &mut g, &mut l, &r);
+    synd(&mut s, &g, &l, &r);
 
     bm(&mut locator, &mut s);
 
-    root(&mut images, &mut locator, &mut l);
+    root(&mut images, &locator, &l);
 
     e[0..SYS_N / 8].fill(0);
 
@@ -61,7 +59,7 @@ pub(crate) fn decrypt(
         w += t as i32;
     }
 
-    synd(&mut s_cmp, &mut g, &mut l, e);
+    synd(&mut s_cmp, &g, &l, e);
 
     let mut check = w as u16;
     check ^= SYS_T as u16;

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -38,7 +38,7 @@ fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8; SYS_N / 8], rng: &mut R) {
         // moving and counting indices in the correct range
 
         let mut count = 0;
-        for itr_num in nums.iter().take(SYS_T * 2) {
+        for itr_num in nums.iter() {
             if count >= SYS_T {
                 break;
             }
@@ -73,7 +73,7 @@ fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8; SYS_N / 8], rng: &mut R) {
         val[j] = 1 << (ind[j] & 7);
     }
 
-    for (i, itr_e) in e.iter_mut().enumerate().take(SYS_N / 8) {
+    for (i, itr_e) in e.iter_mut().enumerate() {
         *itr_e = 0;
 
         for j in 0..SYS_T {

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -38,12 +38,12 @@ fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8; SYS_N / 8], rng: &mut R) {
         // moving and counting indices in the correct range
 
         let mut count = 0;
-        for i in 0..(SYS_T * 2) {
+        for itr_num in nums.iter().take(SYS_T * 2) {
             if count >= SYS_T {
                 break;
             }
-            if nums[i] < SYS_N as u16 {
-                ind[count] = nums[i];
+            if *itr_num < SYS_N as u16 {
+                ind[count] = *itr_num;
                 count += 1;
             }
         }
@@ -73,13 +73,13 @@ fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8; SYS_N / 8], rng: &mut R) {
         val[j] = 1 << (ind[j] & 7);
     }
 
-    for i in 0..SYS_N / 8 {
-        e[i] = 0;
+    for (i, itr_e) in e.iter_mut().enumerate().take(SYS_N / 8) {
+        *itr_e = 0;
 
         for j in 0..SYS_T {
             let mask: u8 = same_mask_u8(i as u16, ind[j] >> 3);
 
-            e[i] |= val[j] & mask;
+            *itr_e |= val[j] & mask;
         }
     }
 }

--- a/src/gf.rs
+++ b/src/gf.rs
@@ -268,14 +268,14 @@ pub(crate) fn gf_mul_inplace(out: &mut [Gf; SYS_T], in0: &[Gf; SYS_T], in1: &[Gf
         {
             prod[i - SYS_T + 3] ^= prod[i];
             prod[i - SYS_T + 1] ^= prod[i];
-            prod[i - SYS_T + 0] ^= gf_mul(prod[i], 2);
+            prod[i - SYS_T] ^= gf_mul(prod[i], 2);
         }
         #[cfg(any(feature = "mceliece460896", feature = "mceliece460896f"))]
         {
             prod[i - SYS_T + 10] ^= prod[i];
             prod[i - SYS_T + 9] ^= prod[i];
             prod[i - SYS_T + 6] ^= prod[i];
-            prod[i - SYS_T + 0] ^= prod[i];
+            prod[i - SYS_T] ^= prod[i];
         }
         #[cfg(any(feature = "mceliece6960119", feature = "mceliece6960119f"))]
         {

--- a/src/int32_sort.rs
+++ b/src/int32_sort.rs
@@ -122,8 +122,8 @@ mod tests {
     fn test_int32_sort() {
         let mut array: [i32; 64] = [0; 64];
 
-        for i in 0..array.len() {
-            array[i] = gen_random_i32();
+        for a in array.iter_mut() {
+            *a = gen_random_i32();
             //println!("{}", array[i]);
         }
 
@@ -132,7 +132,7 @@ mod tests {
         for i in 0..array.len() {
             //println!("{}", array[i]);
             if i >= 1 {
-                assert_eq!(array[i] > array[i - 1], true);
+                assert!(array[i] > array[i - 1]);
             }
         }
     }

--- a/src/int32_sort.rs
+++ b/src/int32_sort.rs
@@ -24,6 +24,7 @@ pub(crate) fn int32_sort(x: &mut [i32]) {
         return;
     }
     top = 1;
+    #[allow(clippy::overflow_check_conditional)]
     while top < n - top {
         top += top;
     }

--- a/src/int32_sort.rs
+++ b/src/int32_sort.rs
@@ -24,8 +24,7 @@ pub(crate) fn int32_sort(x: &mut [i32]) {
         return;
     }
     top = 1;
-    #[allow(clippy::overflow_check_conditional)]
-    while top < n - top {
+    while top < n.wrapping_sub(top) {
         top += top;
     }
 

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -281,7 +281,7 @@ pub(crate) fn crypto_kem_keypair<R: CryptoRng + RngCore>(
             f[i] = load_gf(sub!(chunk, 0, 2));
         }
 
-        if genpoly_gen(&mut irr, &mut f) != 0 {
+        if genpoly_gen(&mut irr, &f) != 0 {
             continue;
         }
 
@@ -322,14 +322,14 @@ pub(crate) fn crypto_kem_keypair<R: CryptoRng + RngCore>(
             feature = "mceliece8192128"
         ))]
         {
-            if pk_gen(pk, sub!(mut sk, 40, IRR_BYTES), &mut perm, &mut pi) != 0 {
+            if pk_gen(pk, sub!(mut sk, 40, IRR_BYTES), &perm, &mut pi) != 0 {
                 continue;
             }
         }
 
         controlbitsfrompermutation(
             &mut sk[(40 + IRR_BYTES)..(40 + IRR_BYTES + COND_BYTES)],
-            &mut pi,
+            &pi,
             GFBITS,
             1 << GFBITS,
         );

--- a/src/pk_gen.rs
+++ b/src/pk_gen.rs
@@ -243,7 +243,7 @@ pub(crate) fn pk_gen(
 
     root(&mut inv, &g, &l);
 
-    for itr_inv in inv.iter_mut().take(SYS_N) {
+    for itr_inv in inv.iter_mut() {
         *itr_inv = gf_inv(*itr_inv);
     }
 

--- a/src/pk_gen.rs
+++ b/src/pk_gen.rs
@@ -243,8 +243,8 @@ pub(crate) fn pk_gen(
 
     root(&mut inv, &g, &l);
 
-    for i in 0..SYS_N {
-        inv[i] = gf_inv(inv[i]);
+    for itr_inv in inv.iter_mut().take(SYS_N) {
+        *itr_inv = gf_inv(*itr_inv);
     }
 
     for i in 0..SYS_T {
@@ -264,7 +264,7 @@ pub(crate) fn pk_gen(
                 b <<= 1;
                 b |= ((inv[j + 1] >> k) & 1) as u8;
                 b <<= 1;
-                b |= ((inv[j + 0] >> k) & 1) as u8;
+                b |= ((inv[j] >> k) & 1) as u8;
 
                 mat[i * GFBITS + k][j / 8] = b;
             }

--- a/src/root.rs
+++ b/src/root.rs
@@ -57,8 +57,8 @@ mod tests {
             out[i] = (i as Gf).wrapping_add(3);
             l[i] = (i as Gf).wrapping_add(7);
         }
-        for i in 0..(SYS_T + 1) {
-            f[i] = (i as Gf).wrapping_mul(3);
+        for (i, f) in f.iter_mut().enumerate() {
+            *f = (i as Gf).wrapping_mul(3);
         }
 
         root(&mut out, &f, &l);

--- a/src/sk_gen.rs
+++ b/src/sk_gen.rs
@@ -11,7 +11,7 @@ pub(crate) fn genpoly_gen(out: &mut [Gf; SYS_T], f: &[Gf; SYS_T]) -> isize {
 
     mat[0][1..SYS_T].fill(0);
 
-    mat[1][..SYS_T].copy_from_slice(&f[..SYS_T]);
+    mat[1] = *f;
 
     for j in 2..=SYS_T {
         let (left, right) = mat.split_at_mut(j);

--- a/src/sk_gen.rs
+++ b/src/sk_gen.rs
@@ -35,7 +35,7 @@ pub(crate) fn genpoly_gen(out: &mut [Gf; SYS_T], f: &[Gf; SYS_T]) -> isize {
 
         let inv = gf_inv(mat[j][j]);
 
-        for itr_mat in mat.iter_mut().take(SYS_T + 1).skip(j) {
+        for itr_mat in mat.iter_mut() {
             itr_mat[j] = gf_mul(itr_mat[j], inv);
         }
 
@@ -43,7 +43,7 @@ pub(crate) fn genpoly_gen(out: &mut [Gf; SYS_T], f: &[Gf; SYS_T]) -> isize {
             if k != j {
                 let t = mat[j][k];
 
-                for itr_mat in mat.iter_mut().take(SYS_T + 1).skip(j) {
+                for itr_mat in mat.iter_mut() {
                     itr_mat[k] ^= gf_mul(itr_mat[j], t);
                 }
             }

--- a/src/sk_gen.rs
+++ b/src/sk_gen.rs
@@ -11,13 +11,11 @@ pub(crate) fn genpoly_gen(out: &mut [Gf; SYS_T], f: &[Gf; SYS_T]) -> isize {
 
     mat[0][1..SYS_T].fill(0);
 
-    for i in 0..SYS_T {
-        mat[1][i] = f[i];
-    }
+    mat[1][..SYS_T].copy_from_slice(&f[..SYS_T]);
 
     for j in 2..=SYS_T {
         let (left, right) = mat.split_at_mut(j);
-        gf_mul_inplace(&mut right[0], &mut left[j - 1], f);
+        gf_mul_inplace(&mut right[0], &left[j - 1], f);
     }
 
     for j in 0..SYS_T {
@@ -37,16 +35,16 @@ pub(crate) fn genpoly_gen(out: &mut [Gf; SYS_T], f: &[Gf; SYS_T]) -> isize {
 
         let inv = gf_inv(mat[j][j]);
 
-        for c in j..(SYS_T + 1) {
-            mat[c][j] = gf_mul(mat[c][j], inv);
+        for itr_mat in mat.iter_mut().take(SYS_T + 1).skip(j) {
+            itr_mat[j] = gf_mul(itr_mat[j], inv);
         }
 
         for k in 0..SYS_T {
             if k != j {
                 let t = mat[j][k];
 
-                for c in j..(SYS_T + 1) {
-                    mat[c][k] ^= gf_mul(mat[c][j], t);
+                for itr_mat in mat.iter_mut().take(SYS_T + 1).skip(j) {
+                    itr_mat[k] ^= gf_mul(itr_mat[j], t);
                 }
             }
         }

--- a/src/synd.rs
+++ b/src/synd.rs
@@ -19,7 +19,7 @@ pub(crate) fn synd(
         let e: Gf = eval(f, l[i]);
         let mut e_inv: Gf = gf_inv(gf_mul(e, e));
 
-        for itr_out in out.iter_mut().take(SYS_T * 2) {
+        for itr_out in out.iter_mut() {
             *itr_out = gf_add(*itr_out, gf_mul(e_inv, c));
             e_inv = gf_mul(e_inv, l[i]);
         }

--- a/src/synd.rs
+++ b/src/synd.rs
@@ -19,8 +19,8 @@ pub(crate) fn synd(
         let e: Gf = eval(f, l[i]);
         let mut e_inv: Gf = gf_inv(gf_mul(e, e));
 
-        for j in 0..SYS_T * 2 {
-            out[j] = gf_add(out[j], gf_mul(e_inv, c));
+        for itr_out in out.iter_mut().take(SYS_T * 2) {
+            *itr_out = gf_add(*itr_out, gf_mul(e_inv, c));
             e_inv = gf_mul(e_inv, l[i]);
         }
     }

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -12,9 +12,7 @@ pub(crate) fn transpose(output: &mut [u64; 64], input: [u64; 64]) {
         [0x00000000FFFFFFFF, 0xFFFFFFFF00000000],
     ];
 
-    for h in 0..64 {
-        output[h] = input[h];
-    }
+    output[..64].copy_from_slice(&input[..64]);
 
     for d in (0..=5).rev() {
         let s = 1 << d;

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -12,7 +12,7 @@ pub(crate) fn transpose(output: &mut [u64; 64], input: [u64; 64]) {
         [0x00000000FFFFFFFF, 0xFFFFFFFF00000000],
     ];
 
-    output[..64].copy_from_slice(&input[..64]);
+    *output = input;
 
     for d in (0..=5).rev() {
         let s = 1 << d;

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -355,19 +355,19 @@ mod tests {
             ],
         };
 
-        for i in 0..2 {
+        for testcase in testcases {
             #[cfg(not(any(feature = "mceliece348864", feature = "mceliece348864f")))]
             {
                 let mut test_output: [u64; 64] = [0; 64];
-                transpose(&mut test_output, testcases[i].input);
-                assert_eq!(test_output, testcases[i].output);
+                transpose(&mut test_output, testcase.input);
+                assert_eq!(test_output, testcase.output);
             }
 
             #[cfg(any(feature = "mceliece348864", feature = "mceliece348864f"))]
             {
-                let mut data = testcases[i].input;
+                let mut data = testcase.input;
                 transpose_64x64_inplace(&mut data);
-                assert_eq!(data, testcases[i].output);
+                assert_eq!(data, testcase.output);
             }
         }
     }

--- a/src/uint64_sort.rs
+++ b/src/uint64_sort.rs
@@ -28,6 +28,7 @@ pub(crate) fn uint64_sort<const N: usize>(x: &mut [u64; N]) {
         return;
     }
     let mut top = 1;
+    #[allow(clippy::overflow_check_conditional)]
     while top < N - top {
         top += top;
     }

--- a/src/uint64_sort.rs
+++ b/src/uint64_sort.rs
@@ -28,8 +28,8 @@ pub(crate) fn uint64_sort<const N: usize>(x: &mut [u64; N]) {
         return;
     }
     let mut top = 1;
-    #[allow(clippy::overflow_check_conditional)]
-    while top < N - top {
+
+    while top < N.wrapping_sub(top) {
         top += top;
     }
 

--- a/src/uint64_sort.rs
+++ b/src/uint64_sort.rs
@@ -105,8 +105,7 @@ mod tests {
             let (x, y) = uint64_minmax(x, y);
 
             if x > y {
-                assert!(
-                    false,
+                panic!(
                     "erroneous behaviour with inputs: x: 0x{:016X}u64 y: 0x{:016X}u64",
                     x, y
                 );
@@ -118,8 +117,8 @@ mod tests {
     fn test_uint64_sort_random_numbers() {
         let mut array: [u64; 64] = [0; 64];
 
-        for i in 0..array.len() {
-            array[i] = gen_random_u64();
+        for a in array.iter_mut() {
+            *a = gen_random_u64();
         }
 
         uint64_sort(&mut array);

--- a/tests/katkem.sh
+++ b/tests/katkem.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+declare -A variants
+variants["mceliece348864"]="d2def196fde89e938d3d45b2c6f806aa"
+variants["mceliece348864f"]="84b5357d8dd656bed9297e28beb15057"
+variants["mceliece460896"]="8aac2122916b901172e49e009efeede6"
+variants["mceliece460896f"]="d84d3b179e303b9f3fc32ccb6befb886"
+variants["mceliece6688128"]="b86987d56c45da2e326556864e66bda7"
+variants["mceliece6688128f"]="ae1e42cac2a885a87a2c241e05391481"
+variants["mceliece6960119"]="9d9b3c9e8d7595503248131c584394be"
+variants["mceliece6960119f"]="c79b1bd28fd307f8d157bd566374bfb3"
+variants["mceliece8192128"]="b233e2585359a1133a1135c66fa48282"
+variants["mceliece8192128f"]="d21bcb80dde24826e2c14254da917df3"
+
+RET=0
+TMPDIR=$(mktemp -d) 
+for var in "${!variants[@]}" 
+do
+    cargo run --release --features "$var" --example katkem -- $TMPDIR/$var.req $TMPDIR/$var.rsp
+    MD5HASH=$(md5sum ${TMPDIR}/${var}.rsp | awk '{print $1}')
+    if [[ "$MD5HASH" != "${variants[$var]}" ]]; then
+        echo "KAT not as expected for ${var}."
+        RET=1
+    fi
+done
+rm -R $TMPDIR
+exit $RET
+    
+
+


### PR DESCRIPTION
In summary I refactored some for loops using iterators and a few `copy_from_slice` instances. After that I ran `cargo test` and the tests went through, however please review my changes :) 

also I'm not entirely sure about the iterator naming convention you would prefer, so please give feedback 

The three remaining clippy warnings I currently addressed with e.g. `#[allow(clippy::overflow_check_conditional)]` attributes? (if they are called like this in rust) since I'm not sure yet how to address them properly

There was one clippy warning in particular which complained about too many function parameters in controlbits