### PR TITLE
Add #[must_use] to keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ impl<'a, const SIZE: usize> zeroize::Zeroize for KeyBuffer<'a, SIZE> {
 /// A Classic McEliece public key. These are very large compared to keys
 /// in most other cryptographic algorithms.
 #[derive(Debug)]
+#[must_use]
 pub struct PublicKey<'a>(KeyBuffer<'a, CRYPTO_PUBLICKEYBYTES>);
 
 impl<'a> PublicKey<'a> {
@@ -146,6 +147,7 @@ impl<'a> AsRef<[u8]> for PublicKey<'a> {
 ///
 /// Should be kept on the device where it's generated. Used to decapsulate the [`SharedSecret`]
 /// from the [`Ciphertext`] received from the encapsulator.
+#[must_use]
 pub struct SecretKey<'a>(KeyBuffer<'a, CRYPTO_SECRETKEYBYTES>);
 
 impl<'a> SecretKey<'a> {
@@ -195,6 +197,7 @@ impl<'a> Drop for SecretKey<'a> {
 
 /// The ciphertext computed by the encapsulator.
 #[derive(Debug)]
+#[must_use]
 pub struct Ciphertext([u8; CRYPTO_CIPHERTEXTBYTES]);
 
 impl Ciphertext {
@@ -211,6 +214,7 @@ impl AsRef<[u8]> for Ciphertext {
 
 /// The shared secret computed by the KEM. Returned from both the
 /// encapsulator and decapsulator.
+#[must_use]
 pub struct SharedSecret<'a>(KeyBuffer<'a, CRYPTO_BYTES>);
 
 impl<'a> SharedSecret<'a> {


### PR DESCRIPTION
I ran into some footguns when I tried to use the new API of this library in a real application. This PR aims to help avoid those. Even though I designed much of this new API I still managed to accidentally do the following:

```rust
let mut shared_secret = [0; 32];
decapsulate(&ciphertext, &secret_key, &mut shared_secret);
Ok(shared_secret)
```

What's wrong here? Well, `decapsulate` returns a `SharedSecret` that implements `ZeroizeOnDrop`. The shared keys I got out of this code was always just zeroes :shrug:

The first reaction to this might be: Why did we complicate stuff so much? The old API where we passed in mutable slices and then just read the key data from the slices was way simpler. Yes, that part is true. But it is best practice to zero out cryptographic material asap after use. And it is good practice to try to keep the material in a single place in memory (to make the zeroing actually help in any way).

Adding these `#[must_use]` annotations gives me a warning if I try to write the code above. So this is way better.