### PR TITLE
Allow instantiating key/ciphertext types from byte arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ mceliece6960119f = []
 mceliece8192128 = []
 mceliece8192128f = []
 
+[[example]]
+name = "client-server"
+required-features = ["alloc"]
+
 [[bench]]
 name = "kem_api"
 harness = false

--- a/examples/client-server.rs
+++ b/examples/client-server.rs
@@ -1,0 +1,89 @@
+//! This example tries to mimic what a real application would use the library for:
+//! Performing a the key exchange between two computers over a network.
+//! Here the "network" is simulated by simple message passing channels sending heap
+//! allocated byte buffers.
+
+use classic_mceliece_rust::{
+    decapsulate_boxed, encapsulate_boxed, keypair_boxed, Ciphertext, PublicKey, SharedSecret,
+    CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES,
+};
+use rand::thread_rng;
+use std::sync::mpsc::{self, Sender};
+use std::thread;
+
+type Error = Box<dyn std::error::Error>;
+
+fn main() -> Result<(), Error> {
+    let mut server_sender = spawn_server();
+
+    let shared_secret1 = run_client(&mut server_sender)?;
+    println!(
+        "[client] computed shared secret {:?}",
+        hex::encode_upper(shared_secret1)
+    );
+
+    let shared_secret2 = run_client(&mut server_sender)?;
+    println!(
+        "[client] computed shared secret {:?}",
+        hex::encode_upper(shared_secret2)
+    );
+
+    Ok(())
+}
+
+fn spawn_server() -> Sender<(Box<[u8]>, Sender<Box<[u8]>>)> {
+    // Convert the bytes read from the client into a `PublicKey`
+    fn parse_public_key<'a>(public_key_data: &'a [u8]) -> Result<PublicKey<'a>, Error> {
+        let public_key_array = <&[u8; CRYPTO_PUBLICKEYBYTES]>::try_from(public_key_data)?;
+        Ok(PublicKey::from(public_key_array))
+    }
+
+    fn handle_request(public_key: &[u8], response_sender: Sender<Box<[u8]>>) {
+        match parse_public_key(public_key) {
+            Ok(public_key) => {
+                let (ciphertext, shared_secret) = encapsulate_boxed(&public_key, &mut thread_rng());
+                println!(
+                    "[server] computed shared secret {:?}",
+                    hex::encode_upper(shared_secret.as_array())
+                );
+                let _ = response_sender.send(Box::new(*ciphertext.as_array()));
+            }
+            Err(e) => eprintln!("[server] Invalid public key: {}", e),
+        }
+    }
+
+    let (sender, receiver) = mpsc::channel::<(Box<[u8]>, Sender<Box<[u8]>>)>();
+    thread::spawn(move || {
+        for (public_key, response_sender) in receiver.iter() {
+            handle_request(&public_key, response_sender);
+        }
+    });
+    sender
+}
+
+/// Negotiate with `server` and return the shared secret.
+fn run_client(
+    server: &mut Sender<(Box<[u8]>, Sender<Box<[u8]>>)>,
+) -> Result<SharedSecret<'static>, Error> {
+    // Convert the bytes read from the server into a `Ciphertext`
+    fn parse_ciphertext(ciphertext_data: &[u8]) -> Result<Ciphertext, Error> {
+        let ciphertext_array = <[u8; CRYPTO_CIPHERTEXTBYTES]>::try_from(ciphertext_data)?;
+        Ok(Ciphertext::from(ciphertext_array))
+    }
+
+    let (public_key, secret_key) = keypair_boxed(&mut thread_rng());
+
+    // Send the public key to the server
+    let (response_sender, response_receiver) = mpsc::channel();
+    server.send((
+        public_key.as_array().to_vec().into_boxed_slice(),
+        response_sender,
+    ))?;
+
+    // Wait for the server to send us the ciphertext back
+    let ciphertext_data = response_receiver.recv()?;
+    let ciphertext = parse_ciphertext(&ciphertext_data)?;
+
+    // Decapsulate the shared secret
+    Ok(decapsulate_boxed(&ciphertext, &secret_key))
+}

--- a/examples/client-server.rs
+++ b/examples/client-server.rs
@@ -2,6 +2,7 @@
 //! Performing a the key exchange between two computers over a network.
 //! Here the "network" is simulated by simple message passing channels sending heap
 //! allocated byte buffers.
+#![cfg(feature = "alloc")]
 
 use classic_mceliece_rust::{
     decapsulate_boxed, encapsulate_boxed, keypair_boxed, Ciphertext, PublicKey, SharedSecret,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,12 @@ impl AsRef<[u8]> for Ciphertext {
     }
 }
 
+impl From<[u8; CRYPTO_CIPHERTEXTBYTES]> for Ciphertext {
+    fn from(data: [u8; CRYPTO_CIPHERTEXTBYTES]) -> Self {
+        Self(data)
+    }
+}
+
 /// The shared secret computed by the KEM. Returned from both the
 /// encapsulator and decapsulator.
 #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,12 @@ impl<'a> SecretKey<'a> {
         SecretKey(self.0.to_owned())
     }
 
+    /// Returns the secret key as an array of bytes.
+    ///
+    /// Please note that depending on your threat model, moving the data out of the
+    /// `SecretKey` can be bad for security. The `SecretKey` type is designed to keep the
+    /// backing data in a single location in memory and zeroing it out when it goes out
+    /// of scope.
     pub fn as_array(&self) -> &[u8; CRYPTO_SECRETKEYBYTES] {
         self.0.as_ref()
     }
@@ -212,6 +218,22 @@ impl<'a> Debug for SecretKey<'a> {
 impl<'a> AsRef<[u8]> for SecretKey<'a> {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl<'a> From<&'a mut [u8; CRYPTO_SECRETKEYBYTES]> for SecretKey<'a> {
+    /// Represents a mutable byte array of the correct size as a `SecretKey`.
+    /// Please note that the array will be zeroed on drop.
+    fn from(data: &'a mut [u8; CRYPTO_SECRETKEYBYTES]) -> Self {
+        Self(KeyBufferMut::Borrowed(data))
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg(feature = "alloc")]
+impl From<Box<[u8; CRYPTO_SECRETKEYBYTES]>> for SecretKey<'static> {
+    fn from(data: Box<[u8; CRYPTO_SECRETKEYBYTES]>) -> Self {
+        Self(KeyBufferMut::Owned(data))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,8 @@ impl<'a> From<&'a [u8; CRYPTO_PUBLICKEYBYTES]> for PublicKey<'a> {
     }
 }
 
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[cfg(feature = "alloc")]
 impl From<Box<[u8; CRYPTO_PUBLICKEYBYTES]>> for PublicKey<'static> {
     fn from(data: Box<[u8; CRYPTO_PUBLICKEYBYTES]>) -> Self {
         Self(KeyBuffer::Owned(data))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ mod macros {
 
 #[derive(Debug)]
 enum KeyBuffer<'a, const SIZE: usize> {
-    Borrowed(&'a mut [u8; SIZE]),
+    Borrowed(&'a [u8; SIZE]),
     #[cfg(feature = "alloc")]
     Owned(Box<[u8; SIZE]>),
 }
@@ -81,9 +81,9 @@ enum KeyBuffer<'a, const SIZE: usize> {
 impl<'a, const SIZE: usize> KeyBuffer<'a, SIZE> {
     #[cfg(feature = "alloc")]
     fn to_owned(&self) -> KeyBuffer<'static, SIZE> {
-        let mut new_buffer = KeyBuffer::Owned(util::alloc_boxed_array::<SIZE>());
-        new_buffer.as_mut().copy_from_slice(self.as_ref());
-        new_buffer
+        let mut new_buffer = util::alloc_boxed_array::<SIZE>();
+        new_buffer.copy_from_slice(self.as_ref());
+        KeyBuffer::Owned(new_buffer)
     }
 }
 
@@ -97,23 +97,49 @@ impl<'a, const SIZE: usize> AsRef<[u8; SIZE]> for KeyBuffer<'a, SIZE> {
     }
 }
 
-impl<'a, const SIZE: usize> AsMut<[u8; SIZE]> for KeyBuffer<'a, SIZE> {
+#[derive(Debug)]
+enum KeyBufferMut<'a, const SIZE: usize> {
+    Borrowed(&'a mut [u8; SIZE]),
+    #[cfg(feature = "alloc")]
+    Owned(Box<[u8; SIZE]>),
+}
+
+impl<'a, const SIZE: usize> KeyBufferMut<'a, SIZE> {
+    #[cfg(feature = "alloc")]
+    fn to_owned(&self) -> KeyBufferMut<'static, SIZE> {
+        let mut new_buffer = util::alloc_boxed_array::<SIZE>();
+        new_buffer.copy_from_slice(self.as_ref());
+        KeyBufferMut::Owned(new_buffer)
+    }
+}
+
+impl<'a, const SIZE: usize> AsRef<[u8; SIZE]> for KeyBufferMut<'a, SIZE> {
+    fn as_ref(&self) -> &[u8; SIZE] {
+        match &self {
+            KeyBufferMut::Borrowed(buf) => buf,
+            #[cfg(feature = "alloc")]
+            KeyBufferMut::Owned(buf) => buf.as_ref(),
+        }
+    }
+}
+
+impl<'a, const SIZE: usize> AsMut<[u8; SIZE]> for KeyBufferMut<'a, SIZE> {
     fn as_mut(&mut self) -> &mut [u8; SIZE] {
         match self {
-            KeyBuffer::Borrowed(buf) => buf,
+            KeyBufferMut::Borrowed(buf) => buf,
             #[cfg(feature = "alloc")]
-            KeyBuffer::Owned(buf) => buf.as_mut(),
+            KeyBufferMut::Owned(buf) => buf.as_mut(),
         }
     }
 }
 
 #[cfg(feature = "zeroize")]
-impl<'a, const SIZE: usize> zeroize::Zeroize for KeyBuffer<'a, SIZE> {
+impl<'a, const SIZE: usize> zeroize::Zeroize for KeyBufferMut<'a, SIZE> {
     fn zeroize(&mut self) {
         match self {
-            KeyBuffer::Borrowed(buf) => buf.zeroize(),
+            KeyBufferMut::Borrowed(buf) => buf.zeroize(),
             #[cfg(feature = "alloc")]
-            KeyBuffer::Owned(buf) => buf.zeroize(),
+            KeyBufferMut::Owned(buf) => buf.zeroize(),
         }
     }
 }
@@ -143,12 +169,24 @@ impl<'a> AsRef<[u8]> for PublicKey<'a> {
     }
 }
 
+impl<'a> From<&'a [u8; CRYPTO_PUBLICKEYBYTES]> for PublicKey<'a> {
+    fn from(data: &'a [u8; CRYPTO_PUBLICKEYBYTES]) -> Self {
+        Self(KeyBuffer::Borrowed(data))
+    }
+}
+
+impl From<Box<[u8; CRYPTO_PUBLICKEYBYTES]>> for PublicKey<'static> {
+    fn from(data: Box<[u8; CRYPTO_PUBLICKEYBYTES]>) -> Self {
+        Self(KeyBuffer::Owned(data))
+    }
+}
+
 /// A Classic McEliece secret key.
 ///
 /// Should be kept on the device where it's generated. Used to decapsulate the [`SharedSecret`]
 /// from the [`Ciphertext`] received from the encapsulator.
 #[must_use]
-pub struct SecretKey<'a>(KeyBuffer<'a, CRYPTO_SECRETKEYBYTES>);
+pub struct SecretKey<'a>(KeyBufferMut<'a, CRYPTO_SECRETKEYBYTES>);
 
 impl<'a> SecretKey<'a> {
     /// Copies the key to the heap and makes it `'static`.
@@ -221,7 +259,7 @@ impl From<[u8; CRYPTO_CIPHERTEXTBYTES]> for Ciphertext {
 /// The shared secret computed by the KEM. Returned from both the
 /// encapsulator and decapsulator.
 #[must_use]
-pub struct SharedSecret<'a>(KeyBuffer<'a, CRYPTO_BYTES>);
+pub struct SharedSecret<'a>(KeyBufferMut<'a, CRYPTO_BYTES>);
 
 impl<'a> SharedSecret<'a> {
     /// Copies the secret to the heap and makes it `'static`.
@@ -280,12 +318,12 @@ pub fn keypair<'public, 'secret, R: CryptoRng + RngCore>(
     secret_key_buf: &'secret mut [u8; CRYPTO_SECRETKEYBYTES],
     rng: &mut R,
 ) -> (PublicKey<'public>, SecretKey<'secret>) {
-    let mut public_key_buf = KeyBuffer::Borrowed(public_key_buf);
-    let mut secret_key_buf = KeyBuffer::Borrowed(secret_key_buf);
+    operations::crypto_kem_keypair(public_key_buf, secret_key_buf, rng);
 
-    operations::crypto_kem_keypair(public_key_buf.as_mut(), secret_key_buf.as_mut(), rng);
-
-    (PublicKey(public_key_buf), SecretKey(secret_key_buf))
+    (
+        PublicKey(KeyBuffer::Borrowed(public_key_buf)),
+        SecretKey(KeyBufferMut::Borrowed(secret_key_buf)),
+    )
 }
 
 /// Convenient wrapper around [`keypair`] that stores the public and private keys on the heap
@@ -295,12 +333,15 @@ pub fn keypair<'public, 'secret, R: CryptoRng + RngCore>(
 pub fn keypair_boxed<R: CryptoRng + RngCore>(
     rng: &mut R,
 ) -> (PublicKey<'static>, SecretKey<'static>) {
-    let mut public_key_buf = KeyBuffer::Owned(util::alloc_boxed_array::<CRYPTO_PUBLICKEYBYTES>());
-    let mut secret_key_buf = KeyBuffer::Owned(util::alloc_boxed_array::<CRYPTO_SECRETKEYBYTES>());
+    let mut public_key_buf = util::alloc_boxed_array::<CRYPTO_PUBLICKEYBYTES>();
+    let mut secret_key_buf = util::alloc_boxed_array::<CRYPTO_SECRETKEYBYTES>();
 
-    operations::crypto_kem_keypair(public_key_buf.as_mut(), secret_key_buf.as_mut(), rng);
+    operations::crypto_kem_keypair(&mut public_key_buf, &mut secret_key_buf, rng);
 
-    (PublicKey(public_key_buf), SecretKey(secret_key_buf))
+    (
+        PublicKey(KeyBuffer::Owned(public_key_buf)),
+        SecretKey(KeyBufferMut::Owned(secret_key_buf)),
+    )
 }
 
 /// KEM Encapsulation.
@@ -314,7 +355,7 @@ pub fn encapsulate<'shared_secret, R: CryptoRng + RngCore>(
     shared_secret_buf: &'shared_secret mut [u8; CRYPTO_BYTES],
     rng: &mut R,
 ) -> (Ciphertext, SharedSecret<'shared_secret>) {
-    let mut shared_secret_buf = KeyBuffer::Borrowed(shared_secret_buf);
+    let mut shared_secret_buf = KeyBufferMut::Borrowed(shared_secret_buf);
     let mut ciphertext_buf = [0u8; CRYPTO_CIPHERTEXTBYTES];
 
     operations::crypto_kem_enc(
@@ -335,7 +376,7 @@ pub fn encapsulate_boxed<R: CryptoRng + RngCore>(
     public_key: &PublicKey<'_>,
     rng: &mut R,
 ) -> (Ciphertext, SharedSecret<'static>) {
-    let mut shared_secret_buf = KeyBuffer::Owned(Box::new([0u8; CRYPTO_BYTES]));
+    let mut shared_secret_buf = KeyBufferMut::Owned(Box::new([0u8; CRYPTO_BYTES]));
     let mut ciphertext_buf = [0u8; CRYPTO_CIPHERTEXTBYTES];
 
     operations::crypto_kem_enc(
@@ -357,7 +398,7 @@ pub fn decapsulate<'shared_secret>(
     secret_key: &SecretKey,
     shared_secret_buf: &'shared_secret mut [u8; CRYPTO_BYTES],
 ) -> SharedSecret<'shared_secret> {
-    let mut shared_secret_buf = KeyBuffer::Borrowed(shared_secret_buf);
+    let mut shared_secret_buf = KeyBufferMut::Borrowed(shared_secret_buf);
 
     operations::crypto_kem_dec(
         shared_secret_buf.as_mut(),
@@ -373,7 +414,7 @@ pub fn decapsulate<'shared_secret>(
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn decapsulate_boxed(ciphertext: &Ciphertext, secret_key: &SecretKey) -> SharedSecret<'static> {
-    let mut shared_secret_buf = KeyBuffer::Owned(Box::new([0u8; CRYPTO_BYTES]));
+    let mut shared_secret_buf = KeyBufferMut::Owned(Box::new([0u8; CRYPTO_BYTES]));
 
     operations::crypto_kem_dec(
         shared_secret_buf.as_mut(),


### PR DESCRIPTION
A flaw was detected when trying to use this library in a real world application: It was not possible to create neither `Ciphertext` nor `PublicKey` from just plain old data. Meaning that if you were implementing a server and you received a public key in a byte buffer from a client, you could not re-create the `PublicKey` and encapsulate with it. Same for the client and `Ciphertext`. This PR fixes that.

Renames the existing `KeyBuffer` to `KeyBufferMut` and creates a new `KeyBuffer` that works on shared immutable data. This new `KeyBuffer` is to be used with `PublicKey`. This works because the public keys do not need to be zeroed out on drop. So mutability is not needed.