### PR TITLE
Improve & fix unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ classic-mceliece-rust = { version = "2.0", default-features = false, features = 
 
 How does one use the API then (be aware that the example also depends on the rand crate)?
 
-```rust
+```rust,no_run
 use classic_mceliece_rust::{keypair, encapsulate, decapsulate};
 use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Assuming this dependency, the simplest and most ergonomic way of using the libra
 is with heap allocated keys and the `*_boxed` KEM step functions. First, we import them:
 
 ```rust
+#[cfg(feature = "alloc")]
 use classic_mceliece_rust::{keypair_boxed, encapsulate_boxed, decapsulate_boxed};
 ```
 
@@ -56,34 +57,36 @@ Followingly, we run the KEM and provide generated keys accordingly.
 Here, we consider an example where we run it in a separate thread (be aware that the example also depends on the rand crate):
 
 ```rust
-use classic_mceliece_rust::{keypair_boxed, encapsulate_boxed, decapsulate_boxed};
+#[cfg(feature = "alloc")] {
+  use classic_mceliece_rust::{keypair_boxed, encapsulate_boxed, decapsulate_boxed};
 
-fn run_kem() {
-  let mut rng = rand::thread_rng();
+  fn run_kem() {
+    let mut rng = rand::thread_rng();
 
-  // Alice computes the keypair
-  let (public_key, secret_key) = keypair_boxed(&mut rng);
+    // Alice computes the keypair
+    let (public_key, secret_key) = keypair_boxed(&mut rng);
 
-  // Send `secret_key` over to Bob.
-  // Bob computes the shared secret and a ciphertext
-  let (ciphertext, shared_secret_bob) = encapsulate_boxed(&public_key, &mut rng);
+    // Send `secret_key` over to Bob.
+    // Bob computes the shared secret and a ciphertext
+    let (ciphertext, shared_secret_bob) = encapsulate_boxed(&public_key, &mut rng);
 
-  // Send `ciphertext` back to Alice.
-  // Alice decapsulates the ciphertext...
-  let shared_secret_alice = decapsulate_boxed(&ciphertext, &secret_key);
+    // Send `ciphertext` back to Alice.
+    // Alice decapsulates the ciphertext...
+    let shared_secret_alice = decapsulate_boxed(&ciphertext, &secret_key);
 
-  // ... and ends up with the same key material as Bob.
-  assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
-}
+    // ... and ends up with the same key material as Bob.
+    assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
+  }
 
-fn main() {
-  std::thread::Builder::new()
-    // This library needs quite a lot of stack space to work
-    .stack_size(2 * 1024 * 1024)
-    .spawn(run_kem)
-    .unwrap()
-    .join()
-    .unwrap();
+  fn main() {
+    std::thread::Builder::new()
+      // This library needs quite a lot of stack space to work
+      .stack_size(2 * 1024 * 1024)
+      .spawn(run_kem)
+      .unwrap()
+      .join()
+      .unwrap();
+  }
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,9 +551,26 @@ mod kem_api {
         }
 
         #[test]
+        #[cfg(feature = "zeroize")]
+        fn test_zeroize() {
+            use crate::{keypair, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
+
+            let mut pk_buffer = [0u8; CRYPTO_PUBLICKEYBYTES];
+            let mut sk_buffer = [5u8; CRYPTO_SECRETKEYBYTES];
+            let mut rng = rand::thread_rng();
+
+            let zeroed_key = [0; CRYPTO_SECRETKEYBYTES];
+
+            let (_, secret_key) = keypair(&mut pk_buffer, &mut sk_buffer, &mut rng);
+            drop(secret_key);
+
+            assert_eq!(zeroed_key, sk_buffer);
+        }
+
+        #[test]
         #[cfg(feature = "mceliece8192128f")]
         fn test_crypto_kem_api_keypair() {
-            use crate::api::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
+            use crate::{keypair_boxed, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
             let entropy_input = <[u8; 48]>::try_from(
                 crate::TestData::new()
@@ -573,7 +590,7 @@ mod kem_api {
             let mut rng_state = crate::nist_aes_rng::AesState::new();
             rng_state.randombytes_init(entropy_input);
 
-            let (sk, pk) = keypair_boxed(&mut rng_state);
+            let (pk, sk) = keypair_boxed(&mut rng_state);
 
             assert_eq!(compare_sk.as_slice(), sk.0.as_ref());
             assert_eq!(compare_pk.as_slice(), pk.0.as_ref());


### PR DESCRIPTION
While investigating our unit tests, it seems that the `test_crypto_kem_api_keypair` didn't work, as a result of 
a mix-up of the return parameters from `keypair_boxed(..)` , should be fixed with the change in this PR :)

Moreover I've added the test for the "zeroize" feature from the readme, which was not included yet in `lib.rs`. Only for feature, `mceliece8192128f` this test seems to blow out the stack currently. So for this specific case, should we run it in a dedicated thread with increased stack size ? 

Lastly, @faern concerning fixing the `test_crypto_kem_api`, I'm not quite sure how to go about, the `CryptoCiphertextBytesTypenum` is used to initialize the EncappedKeySize type of the EncappedKey trait for our Ciphertext struct, so should I create an Ciphertext object and compare it's EncappedKeySize length with the length of an CRYPTO_CIPHERTEXTBYTES array ?

(faern I'd like to invite you to review aswell however, github doesn't let me find/add you as a reviewer)