### PR TITLE
Update rust edition, rand crate, zeroize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Line wrap the file at 100 chars.                                              Th
 * **Security**: in case of vulnerabilities.
 
 
+## [3.2.0] - 2025-10-29
+### Fixed
+- Updated the `rand` crate to 0.9
+- Updated Rust edition to 2024
+- refactor: updated calls to `rand` in order to match Rust 2024 conventions
+- Updated the `zeroize` crate to 1.8
+
 ## [3.1.0] - 2025-02-21
 ### Changed
 - Reduce stack usage on alloc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Line wrap the file at 100 chars.                                              Th
 - Updated the `rand` crate to 0.9
 - Updated Rust edition to 2024
 - refactor: updated calls to `rand` in order to match Rust 2024 conventions
-- Updated the `zeroize` crate to 1.8
 
 ## [3.1.0] - 2025-02-21
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "classic-mceliece-rust"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "aes",
  "criterion",
@@ -251,13 +251,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -330,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de74da99b010cc3a51a4f8a2e368b98f98f21f500091a06d2e8c1657b879ad2"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -435,24 +436,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -460,6 +466,12 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
@@ -645,10 +657,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -818,6 +833,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["/data"]
 rand = { version = "0.9", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 kem = { version = "0.2", optional = true }
-zeroize = { version = "1.8", default-features = false, optional = true }
+zeroize = { version = "1.5", default-features = false, optional = true }
 
 [features]
 ## When adding features or changing the default features, remember to update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,23 +4,23 @@ description = "Pure rust implementation of the PQC scheme Classic McEliece"
 repository = "https://github.com/Colfenor/classic-mceliece-rust"
 readme = "README.md"
 license = "MIT"
-version = "3.1.0"
+version = "3.2.0"
 authors = [
     "Bernhard Berg <b.b_erg@outlook.com>",
     "Lukas Prokop <admin@lukas-prokop.at>",
     "Daniel Kales <daniel.kales@gmail.com>",
     "Linus Färnstrand",
 ]
-edition = "2021"
+edition = "2024"
 keywords = ["pqc", "post-quantum", "cryptography", "decoding"]
 categories = ["cryptography"]
 exclude = ["/data"]
 
 [dependencies]
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.9", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 kem = { version = "0.2", optional = true }
-zeroize = { version = "1.5", default-features = false, optional = true }
+zeroize = { version = "1.8", default-features = false, optional = true }
 
 [features]
 ## When adding features or changing the default features, remember to update
@@ -56,7 +56,7 @@ name = "kem_api"
 harness = false
 
 [dev-dependencies]
-rand = { version = "0.8", features = ["default"] }
+rand = { version = "0.9", features = ["default"] }
 criterion = { version = "0.3", features = ["html_reports"] }
 criterion-cycles-per-byte = "0.1"
 aes = "0.8"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Here, we consider an example where we run it in a separate thread (be aware that
   use classic_mceliece_rust::{keypair_boxed, encapsulate_boxed, decapsulate_boxed};
 
   fn run_kem() {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Alice computes the keypair
     let (public_key, secret_key) = keypair_boxed(&mut rng);
@@ -116,7 +116,7 @@ use classic_mceliece_rust::{keypair, encapsulate, decapsulate};
 use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
 fn main() {
-  let mut rng = rand::thread_rng();
+  let mut rng = rand::rng();
 
   // Please mind that `public_key_buf` is very large.
   let mut public_key_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
@@ -166,7 +166,7 @@ get it from the `as_array` method.
     use classic_mceliece_rust::keypair;
     use classic_mceliece_rust::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     let mut pk_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
     // Initialize to non-zero to show that it has been set to zero by the drop later

--- a/benches/kem_api.rs
+++ b/benches/kem_api.rs
@@ -5,7 +5,7 @@ use classic_mceliece_rust::{decapsulate, encapsulate, keypair, CRYPTO_BYTES};
 use classic_mceliece_rust::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
 pub fn bench_complete_kem(criterion: &mut Criterion<CyclesPerByte>) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut ss_buf_bob = [0u8; CRYPTO_BYTES];
     let mut ss_buf_alice = [0u8; CRYPTO_BYTES];
@@ -34,7 +34,7 @@ pub fn bench_complete_kem(criterion: &mut Criterion<CyclesPerByte>) {
 }
 
 pub fn bench_kem_keypair(criterion: &mut Criterion<CyclesPerByte>) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut pk_buf;
     #[cfg(feature = "alloc")]
@@ -55,7 +55,7 @@ pub fn bench_kem_keypair(criterion: &mut Criterion<CyclesPerByte>) {
 }
 
 pub fn bench_kem_enc(criterion: &mut Criterion<CyclesPerByte>) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut ss_buf = [0u8; CRYPTO_BYTES];
     let mut pk_buf;
@@ -79,7 +79,7 @@ pub fn bench_kem_enc(criterion: &mut Criterion<CyclesPerByte>) {
 }
 
 pub fn bench_kem_dec(criterion: &mut Criterion<CyclesPerByte>) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
     let mut ss_buf = [0u8; CRYPTO_BYTES];
     let mut pk_buf;

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -3,10 +3,8 @@
 use classic_mceliece_rust::{decapsulate, encapsulate, keypair};
 use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
-use rand::thread_rng;
-
 fn main() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
 
     // key generation
     let mut pubkey_buf = [0u8; CRYPTO_PUBLICKEYBYTES]; // WARN: public keys are large - optionally use Box::new()!

--- a/examples/client-server.rs
+++ b/examples/client-server.rs
@@ -7,7 +7,6 @@ use classic_mceliece_rust::{
     decapsulate_boxed, encapsulate_boxed, keypair_boxed, Ciphertext, PublicKey, SharedSecret,
     CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES,
 };
-use rand::thread_rng;
 use std::sync::mpsc::{self, Sender};
 use std::thread;
 
@@ -41,7 +40,7 @@ fn spawn_server() -> Sender<(Box<[u8]>, Sender<Box<[u8]>>)> {
     fn handle_request(public_key: &mut [u8], response_sender: Sender<Box<[u8]>>) {
         match parse_public_key(public_key) {
             Ok(public_key) => {
-                let (ciphertext, shared_secret) = encapsulate_boxed(&public_key, &mut thread_rng());
+                let (ciphertext, shared_secret) = encapsulate_boxed(&public_key, &mut rand::rng());
                 println!(
                     "[server] computed shared secret {:?}",
                     hex::encode_upper(shared_secret.as_array())
@@ -71,7 +70,7 @@ fn run_client(
         Ok(Ciphertext::from(ciphertext_array))
     }
 
-    let (public_key, secret_key) = keypair_boxed(&mut thread_rng());
+    let (public_key, secret_key) = keypair_boxed(&mut rand::rng());
 
     // Send the public key to the server
     let (response_sender, response_receiver) = mpsc::channel();

--- a/src/int32_sort.rs
+++ b/src/int32_sort.rs
@@ -68,7 +68,7 @@ mod tests {
     use rand::Rng;
 
     fn gen_random_i32() -> i32 {
-        rand::thread_rng().gen::<i32>()
+        rand::rng().random::<i32>()
     }
 
     #[test]

--- a/src/nist_aes_rng.rs
+++ b/src/nist_aes_rng.rs
@@ -121,11 +121,6 @@ impl RngCore for AesState {
         Self::aes256_ctr_update(&mut None, &mut self.key, &mut self.v);
         self.reseed_counter += 1;
     }
-
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
 }
 impl CryptoRng for AesState {}
 

--- a/src/test_katkem.rs
+++ b/src/test_katkem.rs
@@ -435,7 +435,7 @@ fn zeroize() {
         let mut pk_buffer = Box::new([0u8; CRYPTO_PUBLICKEYBYTES]);
         let mut sk_buffer = [5u8; CRYPTO_SECRETKEYBYTES];
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let zeroed_pk_buffer = [0; CRYPTO_PUBLICKEYBYTES];
         let zeroed_key = [0; CRYPTO_SECRETKEYBYTES];

--- a/src/uint64_sort.rs
+++ b/src/uint64_sort.rs
@@ -69,7 +69,7 @@ mod tests {
     use rand::Rng;
 
     fn gen_random_u64() -> u64 {
-        rand::thread_rng().gen::<u64>()
+        rand::rng().random::<u64>()
     }
 
     #[test]

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -10,7 +10,7 @@ const MIN_STACK_SIZE_FOR_THIS_CRATE: usize = (CRYPTO_PUBLICKEYBYTES as f32 * 1.8
 #[test]
 fn to_owned_copies_correct_data() {
     fn run() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let mut pk_buf = [0u8; CRYPTO_PUBLICKEYBYTES];
         let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
@@ -53,7 +53,7 @@ fn to_owned_copies_correct_data() {
 #[test]
 fn boxed_versions_dont_trash_the_stack() {
     fn run() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         let (public_key, secret_key) = keypair_boxed(&mut rng);
         let (ciphertext, shared_secret_bob) = encapsulate_boxed(&public_key, &mut rng);
@@ -71,7 +71,7 @@ fn boxed_versions_dont_trash_the_stack() {
 
 #[test]
 fn to_owned_not_copying_to_stack() {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let (public_key, _) = keypair_boxed(&mut rng);
 
     let run = move || {


### PR DESCRIPTION
Hello :-)

The main update I suggest here is that of the `rand` crate.
I'm trying to use your crate in a project that supports multiple PQ primitives. It becomes a bit of a mess when I need to support multiple version of random.

Hope this can be merged!

Cheers,
Georgio