### PR TITLE
stream public keys for encryption/decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -204,21 +204,21 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "generic-array"
@@ -301,16 +301,17 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -347,16 +348,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
-name = "log"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-traits"
@@ -369,15 +364,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "plotters"
@@ -466,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -476,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -486,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -498,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -509,15 +504,21 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -530,11 +531,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
- "serde_derive",
+ "serde_core",
 ]
 
 [[package]]
@@ -548,10 +549,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.210"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -560,14 +570,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -582,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -652,35 +663,22 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -688,28 +686,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -733,9 +734,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
@@ -747,77 +748,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
@@ -845,3 +788,9 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zmij"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,16 @@ mceliece6960119 = []
 mceliece6960119f = []
 mceliece8192128 = []
 mceliece8192128f = []
+embedded-workspace = []
+example-embedded-keys = []
 
 [[example]]
 name = "client-server"
 required-features = ["alloc"]
+
+[[example]]
+name = "encapsulate_static_no_std"
+required-features = ["example-embedded-keys"]
 
 [[bench]]
 name = "kem_api"
@@ -61,6 +67,9 @@ criterion = { version = "0.3", features = ["html_reports"] }
 criterion-cycles-per-byte = "0.1"
 aes = "0.8"
 hex = "0.4.3"
+
+[profile.release]
+# panic = "abort"
 
 [profile.dev]
 opt-level = 1 # reduces runtime for KATNUM=2 from 281s to 11s

--- a/README.md
+++ b/README.md
@@ -213,6 +213,31 @@ $ cargo run --example katkem PQCkemKAT_935.req PQCkemKAT_935.rsp
 $ cargo run --example katkem PQCkemKAT_935.rsp
 ```
 
+### Example helper script
+
+There is a helper to run examples and auto-generate example key files when required:
+
+```bash
+$ ./scripts/run_example.sh
+$ ./scripts/run_example.sh encapsulate_from_file
+$ ./scripts/run_example.sh encapsulate_static_no_std mceliece348864f
+$ ./scripts/run_example.sh katkem -- PQCkemKAT_935.req PQCkemKAT_935.rsp
+```
+
+Notes:
+- Default example is `encapsulate_from_file` and default variant is `mceliece348864`.
+- Pass a variant as the second argument or via `--variant <name>`.
+- The helper generates `examples/keys/public_key_<variant>.bin` and
+  `examples/keys/secret_key_<variant>.bin` on demand.
+- The `encapsulate_static_no_std` example is gated behind the
+  `example-embedded-keys` feature to avoid missing key files during `cargo test`.
+
+If you want to run the embedded example directly, generate the example keys first:
+
+```bash
+$ ./scripts/gen-example-keys.sh --all
+```
+
 The different variants can be enabled through feature flags:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Here, we consider an example where we run it in a separate thread (be aware that
 
     // Send `ciphertext` back to Alice.
     // Alice decapsulates the ciphertext...
+    #[cfg(feature = "embedded-workspace")]
+    let shared_secret_alice = {
+      let mut workspace = classic_mceliece_rust::DecapsulationWorkspace::new();
+      decapsulate_boxed(&ciphertext, &secret_key, &mut workspace)
+    };
+    #[cfg(not(feature = "embedded-workspace"))]
     let shared_secret_alice = decapsulate_boxed(&ciphertext, &secret_key);
 
     // ... and ends up with the same key material as Bob.
@@ -127,6 +133,12 @@ fn main() {
   let (ciphertext, shared_secret_bob) = encapsulate(&public_key, &mut shared_secret_bob_buf, &mut rng);
 
   let mut shared_secret_alice_buf = [0u8; CRYPTO_BYTES];
+  #[cfg(feature = "embedded-workspace")]
+  let shared_secret_alice = {
+    let mut workspace = classic_mceliece_rust::DecapsulationWorkspace::new();
+    decapsulate(&ciphertext, &secret_key, &mut shared_secret_alice_buf, &mut workspace)
+  };
+  #[cfg(not(feature = "embedded-workspace"))]
   let shared_secret_alice = decapsulate(&ciphertext, &secret_key, &mut shared_secret_alice_buf);
 
   assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,6 +5,8 @@
 //! Or:
 //!   ./scripts/run_example.sh basic mceliece348864
 
+#[cfg(feature = "embedded-workspace")]
+use classic_mceliece_rust::DecapsulationWorkspace;
 use classic_mceliece_rust::{decapsulate, encapsulate, keypair};
 use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
@@ -43,6 +45,17 @@ fn main() {
 
     // decapsulation
     let mut shared_secret_alice_buf = [0u8; CRYPTO_BYTES];
+    #[cfg(feature = "embedded-workspace")]
+    let shared_secret_alice = {
+        let mut workspace = DecapsulationWorkspace::new();
+        decapsulate(
+            &ciphertext,
+            &secret_key,
+            &mut shared_secret_alice_buf,
+            &mut workspace,
+        )
+    };
+    #[cfg(not(feature = "embedded-workspace"))]
     let shared_secret_alice = decapsulate(&ciphertext, &secret_key, &mut shared_secret_alice_buf);
     println!("[Alice]\tRunning decapsulation …");
     println!(

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -10,25 +10,6 @@ use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKE
 
 use rand::thread_rng;
 
-use std::fs::File;
-use std::io::{Read, Write};
-
-#[no_mangle]
-pub extern "C" fn getauxval(_type: usize) -> usize {
-    // For AT_HWCAP, you may want to return flags like:
-    // - 1 << 12 for NEON (on ARM)
-    // - 1 << 13 for VFPv4
-
-    // You can inspect `_type` and return different values if needed:
-    // const AT_HWCAP: usize = 16;
-    // match _type {
-    //     AT_HWCAP => 1 << 12, // NEON
-    //     _ => 0,
-    // }
-
-    0 // Generic safe fallback: no hardware features advertised
-}
-
 fn main() {
     let mut rng = thread_rng();
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,9 +1,33 @@
 //! Simple example illustrating shared key negotiation.
+//!
+//! Run:
+//!   cargo run --example basic --features mceliece348864
+//! Or:
+//!   ./scripts/run_example.sh basic mceliece348864
 
 use classic_mceliece_rust::{decapsulate, encapsulate, keypair};
 use classic_mceliece_rust::{CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
 use rand::thread_rng;
+
+use std::fs::File;
+use std::io::{Read, Write};
+
+#[no_mangle]
+pub extern "C" fn getauxval(_type: usize) -> usize {
+    // For AT_HWCAP, you may want to return flags like:
+    // - 1 << 12 for NEON (on ARM)
+    // - 1 << 13 for VFPv4
+
+    // You can inspect `_type` and return different values if needed:
+    // const AT_HWCAP: usize = 16;
+    // match _type {
+    //     AT_HWCAP => 1 << 12, // NEON
+    //     _ => 0,
+    // }
+
+    0 // Generic safe fallback: no hardware features advertised
+}
 
 fn main() {
     let mut rng = thread_rng();

--- a/examples/client-server.rs
+++ b/examples/client-server.rs
@@ -8,6 +8,8 @@
 //! allocated byte buffers.
 #![cfg(feature = "alloc")]
 
+#[cfg(feature = "embedded-workspace")]
+use classic_mceliece_rust::DecapsulationWorkspace;
 use classic_mceliece_rust::{
     decapsulate_boxed, encapsulate_boxed, keypair_boxed, Ciphertext, PublicKey, SharedSecret,
     CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES,
@@ -90,5 +92,13 @@ fn run_client(
     let ciphertext = parse_ciphertext(&ciphertext_data)?;
 
     // Decapsulate the shared secret
-    Ok(decapsulate_boxed(&ciphertext, &secret_key))
+    #[cfg(feature = "embedded-workspace")]
+    {
+        let mut workspace = DecapsulationWorkspace::new();
+        Ok(decapsulate_boxed(&ciphertext, &secret_key, &mut workspace))
+    }
+    #[cfg(not(feature = "embedded-workspace"))]
+    {
+        Ok(decapsulate_boxed(&ciphertext, &secret_key))
+    }
 }

--- a/examples/client-server.rs
+++ b/examples/client-server.rs
@@ -1,4 +1,9 @@
 //! This example tries to mimic a key exchange between two computers over a network.
+//!
+//! Run:
+//!   cargo run --example client-server --features mceliece348864
+//! Or:
+//!   ./scripts/run_example.sh client-server mceliece348864
 //! Here the "network" is simulated by simple message passing channels sending heap
 //! allocated byte buffers.
 #![cfg(feature = "alloc")]

--- a/examples/encapsulate_from_file.rs
+++ b/examples/encapsulate_from_file.rs
@@ -10,18 +10,15 @@
 //! The public key file must contain `CRYPTO_PUBLICKEYBYTES` bytes in row-major order.
 //! A matching secret key file is used to validate decapsulation.
 
-use classic_mceliece_rust::{
-    decapsulate,
-    keypair_boxed,
-    streaming::{encapsulate_from_reader, PublicKeyReader},
-    SecretKey,
-    CRYPTO_BYTES,
-    CRYPTO_PRIMITIVE,
-    CRYPTO_PUBLICKEYBYTES,
-    CRYPTO_SECRETKEYBYTES,
-};
 use aes::cipher::{BlockEncrypt, KeyInit};
 use aes::Aes256;
+#[cfg(feature = "embedded-workspace")]
+use classic_mceliece_rust::DecapsulationWorkspace;
+use classic_mceliece_rust::{
+    decapsulate, keypair_boxed,
+    streaming::{encapsulate_from_reader, PublicKeyReader},
+    SecretKey, CRYPTO_BYTES, CRYPTO_PRIMITIVE, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES,
+};
 use rand::{rngs::StdRng, SeedableRng};
 use sha3::digest::{ExtendableOutput, Update, XofReader};
 use sha3::Shake256;
@@ -286,6 +283,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let secret_key = SecretKey::from(&mut sk_buf);
 
     let mut ss2_buf = [0u8; CRYPTO_BYTES];
+    #[cfg(feature = "embedded-workspace")]
+    let ss2 = {
+        let mut workspace = DecapsulationWorkspace::new();
+        decapsulate(&ciphertext, &secret_key, &mut ss2_buf, &mut workspace)
+    };
+    #[cfg(not(feature = "embedded-workspace"))]
     let ss2 = decapsulate(&ciphertext, &secret_key, &mut ss2_buf);
     if shared_secret.as_array() != ss2.as_array() {
         return Err(Box::new(io::Error::new(

--- a/examples/encapsulate_from_file.rs
+++ b/examples/encapsulate_from_file.rs
@@ -1,0 +1,322 @@
+//! Stream a public key from a file using a fixed-size buffer.
+//!
+//! Run:
+//!   cargo run --example encapsulate_from_file --features mceliece348864
+//! Or:
+//!   ./scripts/run_example.sh encapsulate_from_file mceliece348864
+//!
+//! This example auto-generates missing key files when run directly.
+//!
+//! The public key file must contain `CRYPTO_PUBLICKEYBYTES` bytes in row-major order.
+//! A matching secret key file is used to validate decapsulation.
+
+use classic_mceliece_rust::{
+    decapsulate,
+    keypair_boxed,
+    streaming::{encapsulate_from_reader, PublicKeyReader},
+    SecretKey,
+    CRYPTO_BYTES,
+    CRYPTO_PRIMITIVE,
+    CRYPTO_PUBLICKEYBYTES,
+    CRYPTO_SECRETKEYBYTES,
+};
+use aes::cipher::{BlockEncrypt, KeyInit};
+use aes::Aes256;
+use rand::{rngs::StdRng, SeedableRng};
+use sha3::digest::{ExtendableOutput, Update, XofReader};
+use sha3::Shake256;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::error::Error;
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct TrackingAllocator;
+
+static CURRENT_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+static PEAK_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+impl TrackingAllocator {
+    fn record_alloc(size: usize) {
+        let new_current = CURRENT_ALLOCATED.fetch_add(size, Ordering::Relaxed) + size;
+        let mut peak = PEAK_ALLOCATED.load(Ordering::Relaxed);
+        while new_current > peak {
+            match PEAK_ALLOCATED.compare_exchange(
+                peak,
+                new_current,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(updated) => peak = updated,
+            }
+        }
+    }
+
+    fn record_dealloc(size: usize) {
+        CURRENT_ALLOCATED.fetch_sub(size, Ordering::Relaxed);
+    }
+}
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            Self::record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            Self::record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        Self::record_dealloc(layout.size());
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = System.realloc(ptr, layout, new_size);
+        if !new_ptr.is_null() {
+            let old_size = layout.size();
+            if new_size > old_size {
+                Self::record_alloc(new_size - old_size);
+            } else if old_size > new_size {
+                Self::record_dealloc(old_size - new_size);
+            }
+        }
+        new_ptr
+    }
+}
+
+const DEFAULT_FILE_BUFFER_BYTES: usize = 16 * 1024;
+const MESSAGE_LEN: usize = 11;
+const MESSAGE: [u8; MESSAGE_LEN] = *b"Hello World";
+
+fn derive_aes_key_nonce(shared_secret: &[u8; CRYPTO_BYTES]) -> ([u8; 32], [u8; 16]) {
+    let mut shake = Shake256::default();
+    shake.update(shared_secret);
+    let mut reader = shake.finalize_xof();
+    let mut out = [0u8; 48];
+    reader.read(&mut out);
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&out[..32]);
+    let mut nonce = [0u8; 16];
+    nonce.copy_from_slice(&out[32..]);
+    (key, nonce)
+}
+
+fn aes256_ctr_xor<const N: usize>(
+    key: &[u8; 32],
+    nonce: &[u8; 16],
+    input: &[u8; N],
+    output: &mut [u8; N],
+) {
+    let cipher = Aes256::new(key.into());
+    let mut counter = u128::from_be_bytes(*nonce);
+    for (chunk_out, chunk_in) in output.chunks_mut(16).zip(input.chunks(16)) {
+        let mut block = counter.to_be_bytes();
+        cipher.encrypt_block((&mut block).into());
+        for i in 0..chunk_in.len() {
+            chunk_out[i] = chunk_in[i] ^ block[i];
+        }
+        counter = counter.wrapping_add(1);
+    }
+}
+
+fn aes256_encrypt_decrypt<const N: usize>(
+    shared_secret_enc: &[u8; CRYPTO_BYTES],
+    shared_secret_dec: &[u8; CRYPTO_BYTES],
+    plaintext: &[u8; N],
+) -> [u8; N] {
+    let (enc_key, enc_nonce) = derive_aes_key_nonce(shared_secret_enc);
+    let (dec_key, dec_nonce) = derive_aes_key_nonce(shared_secret_dec);
+    let mut ciphertext = [0u8; N];
+    aes256_ctr_xor(&enc_key, &enc_nonce, plaintext, &mut ciphertext);
+    let mut decrypted = [0u8; N];
+    aes256_ctr_xor(&dec_key, &dec_nonce, &ciphertext, &mut decrypted);
+    decrypted
+}
+
+struct FilePublicKeyReader<'a> {
+    file: File,
+    buffer: &'a mut [u8],
+    buf_pos: usize,
+    buf_len: usize,
+    max_buffered: usize,
+    total_copied: usize,
+}
+
+impl<'a> FilePublicKeyReader<'a> {
+    fn new(file: File, buffer: &'a mut [u8]) -> Self {
+        Self {
+            file,
+            buffer,
+            buf_pos: 0,
+            buf_len: 0,
+            max_buffered: 0,
+            total_copied: 0,
+        }
+    }
+
+    fn refill(&mut self) -> io::Result<()> {
+        self.buf_len = self.file.read(self.buffer)?;
+        self.buf_pos = 0;
+        self.max_buffered = self.max_buffered.max(self.buf_len);
+        if self.buf_len == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "public key file too short",
+            ));
+        }
+        Ok(())
+    }
+
+    fn buffer_bytes(&self) -> usize {
+        self.buffer.len()
+    }
+
+    fn max_buffered(&self) -> usize {
+        self.max_buffered
+    }
+
+    fn total_copied(&self) -> usize {
+        self.total_copied
+    }
+}
+
+impl PublicKeyReader for FilePublicKeyReader<'_> {
+    type Error = io::Error;
+
+    fn read_exact(&mut self, out: &mut [u8]) -> Result<(), Self::Error> {
+        let mut written = 0;
+        while written < out.len() {
+            if self.buf_pos == self.buf_len {
+                self.refill()?;
+            }
+
+            let available = self.buf_len - self.buf_pos;
+            let to_copy = (out.len() - written).min(available);
+            out[written..written + to_copy]
+                .copy_from_slice(&self.buffer[self.buf_pos..self.buf_pos + to_copy]);
+            self.buf_pos += to_copy;
+            written += to_copy;
+            self.total_copied += to_copy;
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        if self.buf_pos < self.buf_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "public key file too long",
+            ));
+        }
+
+        let mut extra = [0u8; 1];
+        let read = self.file.read(&mut extra)?;
+        if read == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "public key file too long",
+            ))
+        }
+    }
+
+    fn invalid_padding(&self) -> Self::Error {
+        io::Error::new(io::ErrorKind::InvalidData, "public key padding invalid")
+    }
+}
+
+fn ensure_keypair_files(pk_path: &Path, sk_path: &Path) -> Result<(), Box<dyn Error>> {
+    if pk_path.exists() && sk_path.exists() {
+        return Ok(());
+    }
+
+    let mut rng = StdRng::from_seed([0xA5; 32]);
+    let (public_key, secret_key) = keypair_boxed(&mut rng);
+    std::fs::write(pk_path, public_key.as_array())?;
+    std::fs::write(sk_path, secret_key.as_array())?;
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let default_pk_path = format!(
+        "{}/examples/keys/public_key_{}.bin",
+        env!("CARGO_MANIFEST_DIR"),
+        CRYPTO_PRIMITIVE
+    );
+    let default_sk_path = format!(
+        "{}/examples/keys/secret_key_{}.bin",
+        env!("CARGO_MANIFEST_DIR"),
+        CRYPTO_PRIMITIVE
+    );
+    let mut args = std::env::args().skip(1);
+    let pk_path = args.next().unwrap_or(default_pk_path);
+    let sk_path = args.next().unwrap_or(default_sk_path);
+    let pk_path_ref = Path::new(&pk_path);
+    let sk_path_ref = Path::new(&sk_path);
+
+    ensure_keypair_files(pk_path_ref, sk_path_ref)?;
+    let file = File::open(pk_path_ref)?;
+    let mut buffer = vec![0u8; DEFAULT_FILE_BUFFER_BYTES];
+    let mut reader = FilePublicKeyReader::new(file, buffer.as_mut_slice());
+
+    let mut shared_secret_buf = [0u8; CRYPTO_BYTES];
+    let mut rng = StdRng::from_seed([0x11; 32]);
+
+    let (ciphertext, shared_secret) =
+        encapsulate_from_reader(&mut reader, &mut shared_secret_buf, &mut rng)?;
+
+    let mut sk_buf = [0u8; CRYPTO_SECRETKEYBYTES];
+    let mut sk_file = File::open(sk_path_ref)?;
+    sk_file.read_exact(&mut sk_buf)?;
+    let secret_key = SecretKey::from(&mut sk_buf);
+
+    let mut ss2_buf = [0u8; CRYPTO_BYTES];
+    let ss2 = decapsulate(&ciphertext, &secret_key, &mut ss2_buf);
+    if shared_secret.as_array() != ss2.as_array() {
+        return Err(Box::new(io::Error::new(
+            io::ErrorKind::Other,
+            "shared secret mismatch",
+        )));
+    }
+
+    let decrypted_message =
+        aes256_encrypt_decrypt(shared_secret.as_array(), ss2.as_array(), &MESSAGE);
+    if decrypted_message != MESSAGE {
+        return Err(Box::new(io::Error::new(
+            io::ErrorKind::Other,
+            "message mismatch",
+        )));
+    }
+
+    println!("public key bytes: {}", CRYPTO_PUBLICKEYBYTES);
+    println!("public key bytes read: {}", reader.total_copied());
+    println!("file buffer bytes: {}", reader.buffer_bytes());
+    println!("max buffered bytes: {}", reader.max_buffered());
+    println!("public key file: {}", pk_path);
+    println!("secret key file: {}", sk_path);
+    println!(
+        "live allocated bytes: {}",
+        CURRENT_ALLOCATED.load(Ordering::Relaxed)
+    );
+    println!(
+        "peak live allocated bytes: {}",
+        PEAK_ALLOCATED.load(Ordering::Relaxed)
+    );
+
+    Ok(())
+}

--- a/examples/encapsulate_static_no_std.rs
+++ b/examples/encapsulate_static_no_std.rs
@@ -12,16 +12,15 @@
 //! `examples/keys/secret_key_<variant>.bin`.
 //! Replace those files with your actual key bytes stored in ROM/flash.
 
+use aes::cipher::{BlockEncrypt, KeyInit};
+use aes::Aes256;
+#[cfg(feature = "embedded-workspace")]
+use classic_mceliece_rust::DecapsulationWorkspace;
 use classic_mceliece_rust::{
     decapsulate,
     streaming::{encapsulate_from_reader, PublicKeyReader},
-    SecretKey,
-    CRYPTO_BYTES,
-    CRYPTO_PUBLICKEYBYTES,
-    CRYPTO_SECRETKEYBYTES,
+    SecretKey, CRYPTO_BYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES,
 };
-use aes::cipher::{BlockEncrypt, KeyInit};
-use aes::Aes256;
 use rand::{CryptoRng, RngCore};
 use sha3::digest::{ExtendableOutput, Update, XofReader};
 use sha3::Shake256;
@@ -159,19 +158,26 @@ impl PublicKeyReader for StaticStorageReader {
     }
 }
 
-struct CounterRng(u64);
+/// Small deterministic RNG for no-std demo runs.
+///
+/// This is *not* cryptographically secure, but unlike a simple counter it
+/// provides enough diffusion to avoid pathological rejection-loop behavior in
+/// `gen_e`.
+struct DemoRng(u64);
 
-impl RngCore for CounterRng {
+impl RngCore for DemoRng {
     fn next_u32(&mut self) -> u32 {
-        let value = self.0 as u32;
-        self.0 = self.0.wrapping_add(1);
-        value
+        self.next_u64() as u32
     }
 
     fn next_u64(&mut self) -> u64 {
-        let value = self.0;
-        self.0 = self.0.wrapping_add(1);
-        value
+        // xorshift64* (deterministic, fast, non-cryptographic)
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
@@ -188,7 +194,7 @@ impl RngCore for CounterRng {
     }
 }
 
-impl CryptoRng for CounterRng {}
+impl CryptoRng for DemoRng {}
 
 fn derive_aes_key_nonce(shared_secret: &[u8; CRYPTO_BYTES]) -> ([u8; 32], [u8; 16]) {
     let mut shake = Shake256::default();
@@ -239,7 +245,7 @@ fn main() {
     #[allow(static_mut_refs)]
     let mut reader = StaticStorageReader::new(unsafe { &mut STATIC_BUFFER });
     let mut shared_secret_buf = [0u8; CRYPTO_BYTES];
-    let mut rng = CounterRng(0x1234_5678_9ABC_DEF0);
+    let mut rng = DemoRng(0x1234_5678_9ABC_DEF0);
 
     let (ciphertext, shared_secret) =
         encapsulate_from_reader(&mut reader, &mut shared_secret_buf, &mut rng)
@@ -248,6 +254,12 @@ fn main() {
     #[allow(static_mut_refs)]
     let secret_key = SecretKey::from(unsafe { &mut SECRET_KEY_BYTES });
     let mut ss2_buf = [0u8; CRYPTO_BYTES];
+    #[cfg(feature = "embedded-workspace")]
+    let ss2 = {
+        let mut workspace = DecapsulationWorkspace::new();
+        decapsulate(&ciphertext, &secret_key, &mut ss2_buf, &mut workspace)
+    };
+    #[cfg(not(feature = "embedded-workspace"))]
     let ss2 = decapsulate(&ciphertext, &secret_key, &mut ss2_buf);
     if shared_secret.as_array() != ss2.as_array() {
         panic!("shared secret mismatch");

--- a/examples/encapsulate_static_no_std.rs
+++ b/examples/encapsulate_static_no_std.rs
@@ -1,0 +1,261 @@
+//! No-std friendly example that reads a public key from a static buffer.
+//!
+//! Run:
+//!   cargo run --example encapsulate_static_no_std --features "mceliece348864 example-embedded-keys"
+//! Or:
+//!   ./scripts/run_example.sh encapsulate_static_no_std mceliece348864
+//!
+//! The key files are loaded via `include_bytes!`. Generate them first via
+//! `./scripts/run_example.sh encapsulate_from_file <variant>`.
+//!
+//! The bytes are loaded from `examples/keys/public_key_<variant>.bin` and
+//! `examples/keys/secret_key_<variant>.bin`.
+//! Replace those files with your actual key bytes stored in ROM/flash.
+
+use classic_mceliece_rust::{
+    decapsulate,
+    streaming::{encapsulate_from_reader, PublicKeyReader},
+    SecretKey,
+    CRYPTO_BYTES,
+    CRYPTO_PUBLICKEYBYTES,
+    CRYPTO_SECRETKEYBYTES,
+};
+use aes::cipher::{BlockEncrypt, KeyInit};
+use aes::Aes256;
+use rand::{CryptoRng, RngCore};
+use sha3::digest::{ExtendableOutput, Update, XofReader};
+use sha3::Shake256;
+
+const STATIC_BUFFER_BYTES: usize = 16 * 1024;
+const MESSAGE_LEN: usize = 11;
+const MESSAGE: [u8; MESSAGE_LEN] = *b"Hello World";
+
+static mut STATIC_BUFFER: [u8; STATIC_BUFFER_BYTES] = [0u8; STATIC_BUFFER_BYTES];
+
+#[cfg(feature = "mceliece348864")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece348864.bin");
+#[cfg(feature = "mceliece348864f")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece348864f.bin");
+#[cfg(feature = "mceliece460896")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece460896.bin");
+#[cfg(feature = "mceliece460896f")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece460896f.bin");
+#[cfg(feature = "mceliece6688128")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece6688128.bin");
+#[cfg(feature = "mceliece6688128f")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece6688128f.bin");
+#[cfg(feature = "mceliece6960119")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece6960119.bin");
+#[cfg(feature = "mceliece6960119f")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece6960119f.bin");
+#[cfg(feature = "mceliece8192128")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece8192128.bin");
+#[cfg(feature = "mceliece8192128f")]
+static PUBLIC_KEY_BYTES: [u8; CRYPTO_PUBLICKEYBYTES] =
+    *include_bytes!("keys/public_key_mceliece8192128f.bin");
+
+#[cfg(feature = "mceliece348864")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece348864.bin");
+#[cfg(feature = "mceliece348864f")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece348864f.bin");
+#[cfg(feature = "mceliece460896")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece460896.bin");
+#[cfg(feature = "mceliece460896f")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece460896f.bin");
+#[cfg(feature = "mceliece6688128")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece6688128.bin");
+#[cfg(feature = "mceliece6688128f")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece6688128f.bin");
+#[cfg(feature = "mceliece6960119")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece6960119.bin");
+#[cfg(feature = "mceliece6960119f")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece6960119f.bin");
+#[cfg(feature = "mceliece8192128")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece8192128.bin");
+#[cfg(feature = "mceliece8192128f")]
+static mut SECRET_KEY_BYTES: [u8; CRYPTO_SECRETKEYBYTES] =
+    *include_bytes!("keys/secret_key_mceliece8192128f.bin");
+
+struct StaticStorageReader {
+    storage_pos: usize,
+    buf_pos: usize,
+    buf_len: usize,
+    buffer: &'static mut [u8],
+}
+
+impl StaticStorageReader {
+    fn new(buffer: &'static mut [u8]) -> Self {
+        Self {
+            storage_pos: 0,
+            buf_pos: 0,
+            buf_len: 0,
+            buffer,
+        }
+    }
+
+    fn refill(&mut self) -> Result<(), ()> {
+        if self.storage_pos >= PUBLIC_KEY_BYTES.len() {
+            return Err(());
+        }
+        let remaining = PUBLIC_KEY_BYTES.len() - self.storage_pos;
+        let to_copy = remaining.min(self.buffer.len());
+        self.buffer[..to_copy]
+            .copy_from_slice(&PUBLIC_KEY_BYTES[self.storage_pos..self.storage_pos + to_copy]);
+        self.storage_pos += to_copy;
+        self.buf_pos = 0;
+        self.buf_len = to_copy;
+        Ok(())
+    }
+}
+
+impl PublicKeyReader for StaticStorageReader {
+    type Error = ();
+
+    fn read_exact(&mut self, out: &mut [u8]) -> Result<(), Self::Error> {
+        let mut written = 0;
+        while written < out.len() {
+            if self.buf_pos == self.buf_len {
+                self.refill()?;
+            }
+
+            let available = self.buf_len - self.buf_pos;
+            let to_copy = (out.len() - written).min(available);
+            out[written..written + to_copy]
+                .copy_from_slice(&self.buffer[self.buf_pos..self.buf_pos + to_copy]);
+            self.buf_pos += to_copy;
+            written += to_copy;
+        }
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        if self.storage_pos == PUBLIC_KEY_BYTES.len() && self.buf_pos == self.buf_len {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    fn invalid_padding(&self) -> Self::Error {
+        ()
+    }
+}
+
+struct CounterRng(u64);
+
+impl RngCore for CounterRng {
+    fn next_u32(&mut self) -> u32 {
+        let value = self.0 as u32;
+        self.0 = self.0.wrapping_add(1);
+        value
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let value = self.0;
+        self.0 = self.0.wrapping_add(1);
+        value
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        for chunk in dest.chunks_mut(8) {
+            let bytes = self.next_u64().to_le_bytes();
+            let len = chunk.len();
+            chunk.copy_from_slice(&bytes[..len]);
+        }
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl CryptoRng for CounterRng {}
+
+fn derive_aes_key_nonce(shared_secret: &[u8; CRYPTO_BYTES]) -> ([u8; 32], [u8; 16]) {
+    let mut shake = Shake256::default();
+    shake.update(shared_secret);
+    let mut reader = shake.finalize_xof();
+    let mut out = [0u8; 48];
+    reader.read(&mut out);
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&out[..32]);
+    let mut nonce = [0u8; 16];
+    nonce.copy_from_slice(&out[32..]);
+    (key, nonce)
+}
+
+fn aes256_ctr_xor<const N: usize>(
+    key: &[u8; 32],
+    nonce: &[u8; 16],
+    input: &[u8; N],
+    output: &mut [u8; N],
+) {
+    let cipher = Aes256::new(key.into());
+    let mut counter = u128::from_be_bytes(*nonce);
+    for (chunk_out, chunk_in) in output.chunks_mut(16).zip(input.chunks(16)) {
+        let mut block = counter.to_be_bytes();
+        cipher.encrypt_block((&mut block).into());
+        for i in 0..chunk_in.len() {
+            chunk_out[i] = chunk_in[i] ^ block[i];
+        }
+        counter = counter.wrapping_add(1);
+    }
+}
+
+fn aes256_encrypt_decrypt<const N: usize>(
+    shared_secret_enc: &[u8; CRYPTO_BYTES],
+    shared_secret_dec: &[u8; CRYPTO_BYTES],
+    plaintext: &[u8; N],
+) -> [u8; N] {
+    let (enc_key, enc_nonce) = derive_aes_key_nonce(shared_secret_enc);
+    let (dec_key, dec_nonce) = derive_aes_key_nonce(shared_secret_dec);
+    let mut ciphertext = [0u8; N];
+    aes256_ctr_xor(&enc_key, &enc_nonce, plaintext, &mut ciphertext);
+    let mut decrypted = [0u8; N];
+    aes256_ctr_xor(&dec_key, &dec_nonce, &ciphertext, &mut decrypted);
+    decrypted
+}
+
+fn main() {
+    #[allow(static_mut_refs)]
+    let mut reader = StaticStorageReader::new(unsafe { &mut STATIC_BUFFER });
+    let mut shared_secret_buf = [0u8; CRYPTO_BYTES];
+    let mut rng = CounterRng(0x1234_5678_9ABC_DEF0);
+
+    let (ciphertext, shared_secret) =
+        encapsulate_from_reader(&mut reader, &mut shared_secret_buf, &mut rng)
+            .expect("encapsulation failed");
+
+    #[allow(static_mut_refs)]
+    let secret_key = SecretKey::from(unsafe { &mut SECRET_KEY_BYTES });
+    let mut ss2_buf = [0u8; CRYPTO_BYTES];
+    let ss2 = decapsulate(&ciphertext, &secret_key, &mut ss2_buf);
+    if shared_secret.as_array() != ss2.as_array() {
+        panic!("shared secret mismatch");
+    }
+
+    let decrypted_message =
+        aes256_encrypt_decrypt(shared_secret.as_array(), ss2.as_array(), &MESSAGE);
+    if decrypted_message != MESSAGE {
+        panic!("message mismatch");
+    }
+}

--- a/scripts/gen-example-keys.sh
+++ b/scripts/gen-example-keys.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/gen-example-keys.sh [--all] [variant...]
+
+Generate missing example key files under examples/keys.
+
+Examples:
+  ./scripts/gen-example-keys.sh
+  ./scripts/gen-example-keys.sh mceliece348864f
+  ./scripts/gen-example-keys.sh --all
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+CARGO_BIN="${CARGO_BIN:-cargo}"
+
+variants=()
+if [[ "${1:-}" == "--all" ]]; then
+  variants=(
+    mceliece348864
+    mceliece348864f
+    mceliece460896
+    mceliece460896f
+    mceliece6688128
+    mceliece6688128f
+    mceliece6960119
+    mceliece6960119f
+    mceliece8192128
+    mceliece8192128f
+  )
+  shift
+elif [[ $# -gt 0 ]]; then
+  variants=("$@")
+else
+  variants=("mceliece348864")
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+keys_dir="$root_dir/examples/keys"
+mkdir -p "$keys_dir"
+
+for variant in "${variants[@]}"; do
+  pk_path="$keys_dir/public_key_${variant}.bin"
+  sk_path="$keys_dir/secret_key_${variant}.bin"
+  if [[ -f "$pk_path" && -f "$sk_path" ]]; then
+    continue
+  fi
+  echo "Generating example keys for ${variant}..."
+  "$CARGO_BIN" run --example encapsulate_from_file --features "${variant}" -- "$pk_path" "$sk_path"
+done

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./run-examples.sh [--all] [variant...]
+
+Runs the file-based example (encapsulate_from_file).
+
+Examples:
+  ./run-examples.sh
+  ./run-examples.sh mceliece348864f
+  ./run-examples.sh --all
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+variants=()
+if [[ "${1:-}" == "--all" ]]; then
+  variants=(
+    mceliece348864
+    mceliece348864f
+    mceliece460896
+    mceliece460896f
+    mceliece6688128
+    mceliece6688128f
+    mceliece6960119
+    mceliece6960119f
+    mceliece8192128
+    mceliece8192128f
+  )
+  shift
+elif [[ $# -gt 0 ]]; then
+  variants=("$@")
+else
+  variants=("mceliece6688128")
+fi
+
+for variant in "${variants[@]}"; do
+  echo "== ${variant} =="
+  cargo run --example encapsulate_from_file --features "${variant}"
+done

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/run_example.sh [example] [variant] [-- <example args>]
+
+Runs a single example, auto-generating example key files if needed.
+
+Examples:
+  ./scripts/run_example.sh encapsulate_from_file
+  ./scripts/run_example.sh encapsulate_static_no_std mceliece348864f
+  ./scripts/run_example.sh katkem -- PQCkemKAT_935.req PQCkemKAT_935.rsp
+  ./scripts/run_example.sh basic
+
+Notes:
+  - Default example is encapsulate_from_file.
+  - Default variant is mceliece348864.
+  - Key files are generated under examples/keys when required.
+EOF
+}
+
+CARGO_BIN="${CARGO_BIN:-cargo}"
+
+variants=(
+  mceliece348864
+  mceliece348864f
+  mceliece460896
+  mceliece460896f
+  mceliece6688128
+  mceliece6688128f
+  mceliece6960119
+  mceliece6960119f
+  mceliece8192128
+  mceliece8192128f
+)
+
+is_variant() {
+  local candidate="$1"
+  for v in "${variants[@]}"; do
+    if [[ "$candidate" == "$v" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+example="${1:-encapsulate_from_file}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+variant="mceliece348864"
+extra_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --variant)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for --variant" >&2
+        exit 1
+      fi
+      variant="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      extra_args+=("$@")
+      break
+      ;;
+    *)
+      if is_variant "$1" && [[ "$variant" == "mceliece348864" ]]; then
+        variant="$1"
+        shift
+      else
+        extra_args+=("$1")
+        shift
+      fi
+      ;;
+  esac
+done
+
+if ! is_variant "$variant"; then
+  echo "Unknown variant: $variant" >&2
+  usage
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+cd "$root_dir"
+
+if [[ ! -f "$root_dir/examples/${example}.rs" ]]; then
+  echo "Unknown example: $example" >&2
+  usage
+  exit 1
+fi
+
+keys_dir="$root_dir/examples/keys"
+pk_path="$keys_dir/public_key_${variant}.bin"
+sk_path="$keys_dir/secret_key_${variant}.bin"
+generated_keys=0
+
+ensure_keys() {
+  mkdir -p "$keys_dir"
+  if [[ -f "$pk_path" && -f "$sk_path" ]]; then
+    return 0
+  fi
+  echo "Generating example keys for ${variant}..."
+  "$CARGO_BIN" run --example encapsulate_from_file --features "${variant}" -- "$pk_path" "$sk_path"
+  generated_keys=1
+}
+
+features="$variant"
+if [[ "$example" == "encapsulate_static_no_std" ]]; then
+  features="${variant} example-embedded-keys"
+fi
+
+if [[ "$example" == "encapsulate_from_file" ]]; then
+  if [[ ${#extra_args[@]} -ge 1 ]]; then
+    pk_path="${extra_args[0]}"
+  fi
+  if [[ ${#extra_args[@]} -ge 2 ]]; then
+    sk_path="${extra_args[1]}"
+  fi
+  extra_args=("$pk_path" "$sk_path")
+  ensure_keys
+  if [[ "$generated_keys" -eq 1 ]]; then
+    exit 0
+  fi
+elif [[ "$example" == "encapsulate_static_no_std" ]]; then
+  ensure_keys
+fi
+
+"$CARGO_BIN" run --example "$example" --features "$features" -- "${extra_args[@]}"

--- a/scripts/test-all-variation.sh
+++ b/scripts/test-all-variation.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/test-all-variation.sh [--release]
+
+Runs tests for all Classic McEliece variants. Use --release to run in release mode.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+release_flag=""
+if [[ "${1:-}" == "--release" ]]; then
+  release_flag="--release"
+  shift
+fi
+
+if [[ $# -gt 0 ]]; then
+  echo "Unexpected arguments: $*" >&2
+  usage
+  exit 1
+fi
+
+CARGO_BIN="${CARGO_BIN:-cargo}"
+
+variants=(
+  mceliece348864
+  mceliece348864f
+  mceliece460896
+  mceliece460896f
+  mceliece6688128
+  mceliece6688128f
+  mceliece6960119
+  mceliece6960119f
+  mceliece8192128
+  mceliece8192128f
+)
+
+echo "==> generating example keys (if missing)"
+CARGO_BIN="$CARGO_BIN" ./scripts/gen-example-keys.sh --all
+echo
+
+for variant in "${variants[@]}"; do
+  echo "==> cargo test ${release_flag} --features ${variant}"
+  "$CARGO_BIN" test ${release_flag} --features "${variant}"
+  echo
+done

--- a/src/benes.rs
+++ b/src/benes.rs
@@ -11,15 +11,14 @@ use crate::params::{COND_BYTES, GFBITS};
 use crate::transpose;
 use crate::util;
 
-#[cfg(feature = "embedded-workspace")]
-struct SupportGenWorkspace {
-    l: [[u8; (1 << GFBITS) / 8]; GFBITS],
-}
-
-#[cfg(feature = "embedded-workspace")]
-static mut SUPPORT_WS: SupportGenWorkspace = SupportGenWorkspace {
-    l: [[0u8; (1 << GFBITS) / 8]; GFBITS],
-};
+/// Scratch storage required by [`support_gen_with_scratch`].
+///
+/// This caller-provided buffer keeps support generation reentrant and avoids
+/// hidden global mutable state.
+///
+/// The buffer contents are treated as ephemeral working state:
+/// support generation clears it before use and scrubs it again before return.
+pub(crate) type SupportGenScratch = [[u8; (1 << GFBITS) / 8]; GFBITS];
 
 /// Layers of the Beneš network. The required size of `data` and `bits` depends on the value `lgs`.
 /// NOTE const expressions are not sophisticated enough in rust yet to represent this relationship.
@@ -354,26 +353,35 @@ fn apply_benes(r: &mut [u8; 1024], bits: &[u8; COND_BYTES], rev: usize) {
     }
 }
 
-pub(crate) fn support_gen(s: &mut [Gf; SYS_N], c: &[u8; COND_BYTES]) {
+/// Shared implementation of support generation.
+///
+/// `scratch` stores the bit-sliced temporary representation that is permuted by
+/// the Beneš network before being packed into the final support set `s`.
+///
+/// This function clears `scratch` on entry and scrubs it again before returning.
+/// Callers must not rely on any retained scratch contents across invocations.
+fn support_gen_core(s: &mut [Gf; SYS_N], c: &[u8; COND_BYTES], scratch: &mut SupportGenScratch) {
     let mut a: Gf;
-    #[cfg(feature = "embedded-workspace")]
-    let l = unsafe { &mut SUPPORT_WS.l };
-    #[cfg(feature = "embedded-workspace")]
-    for row in l.iter_mut() {
+
+    // Always clear scratch so behavior is deterministic and no stale data from
+    // previous calls is carried over.
+    for row in scratch.iter_mut() {
         row.fill(0);
     }
-    #[cfg(not(feature = "embedded-workspace"))]
-    let mut l = [[0u8; (1 << GFBITS) / 8]; GFBITS];
 
     for i in 0..(1 << GFBITS) {
+        // Elements are prepared in bit-reversed order per reference design.
         a = util::bitrev(i as Gf);
 
-        for (j, itr_l) in l.iter_mut().enumerate() {
+        // Write element bits into a bit-sliced layout:
+        // scratch[j][k] stores the j-th bit for eight consecutive elements.
+        for (j, itr_l) in scratch.iter_mut().enumerate() {
             itr_l[i / 8] |= (((a >> j) & 1) << (i % 8)) as u8;
         }
     }
 
-    for itr_l in l.iter_mut() {
+    // Apply the Benes permutation to each bit plane.
+    for itr_l in scratch.iter_mut() {
         #[cfg(any(feature = "mceliece348864", feature = "mceliece348864f"))]
         {
             apply_benes(itr_l, c, 0);
@@ -384,13 +392,35 @@ pub(crate) fn support_gen(s: &mut [Gf; SYS_N], c: &[u8; COND_BYTES]) {
         }
     }
 
+    // Repack bit-sliced planes back into field elements for the support set.
     for (i, itr_s) in s.iter_mut().enumerate() {
         *itr_s = 0;
         for j in (0..=(GFBITS - 1)).rev() {
             *itr_s <<= 1;
-            *itr_s |= ((l[j][i / 8] >> (i % 8)) & 1) as u16;
+            *itr_s |= ((scratch[j][i / 8] >> (i % 8)) & 1) as u16;
         }
     }
+
+    // Scrub support-generation scratch before return so support-derived
+    // intermediates do not persist in caller-managed long-lived buffers.
+    for row in scratch.iter_mut() {
+        row.fill(0);
+    }
+}
+
+/// Generate support values using caller-provided scratch storage.
+///
+/// This entry point is intended for embedded callers that preallocate a single
+/// workspace and pass it through decapsulation to avoid large stack frames.
+///
+/// The provided `scratch` is overwritten during computation and scrubbed before
+/// this function returns.
+pub(crate) fn support_gen_with_scratch(
+    s: &mut [Gf; SYS_N],
+    c: &[u8; COND_BYTES],
+    scratch: &mut SupportGenScratch,
+) {
+    support_gen_core(s, c, scratch);
 }
 
 #[cfg(test)]

--- a/src/benes.rs
+++ b/src/benes.rs
@@ -11,6 +11,16 @@ use crate::params::{COND_BYTES, GFBITS};
 use crate::transpose;
 use crate::util;
 
+#[cfg(feature = "embedded-workspace")]
+struct SupportGenWorkspace {
+    l: [[u8; (1 << GFBITS) / 8]; GFBITS],
+}
+
+#[cfg(feature = "embedded-workspace")]
+static mut SUPPORT_WS: SupportGenWorkspace = SupportGenWorkspace {
+    l: [[0u8; (1 << GFBITS) / 8]; GFBITS],
+};
+
 /// Layers of the Beneš network. The required size of `data` and `bits` depends on the value `lgs`.
 /// NOTE const expressions are not sophisticated enough in rust yet to represent this relationship.
 ///
@@ -346,6 +356,13 @@ fn apply_benes(r: &mut [u8; 1024], bits: &[u8; COND_BYTES], rev: usize) {
 
 pub(crate) fn support_gen(s: &mut [Gf; SYS_N], c: &[u8; COND_BYTES]) {
     let mut a: Gf;
+    #[cfg(feature = "embedded-workspace")]
+    let l = unsafe { &mut SUPPORT_WS.l };
+    #[cfg(feature = "embedded-workspace")]
+    for row in l.iter_mut() {
+        row.fill(0);
+    }
+    #[cfg(not(feature = "embedded-workspace"))]
     let mut l = [[0u8; (1 << GFBITS) / 8]; GFBITS];
 
     for i in 0..(1 << GFBITS) {

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -1,118 +1,137 @@
 //! Decryption function to turn ciphertext into a ciphertext using the secret key
 
 use crate::{
-    benes::support_gen,
+    benes::{support_gen_with_scratch, SupportGenScratch},
     bm::bm,
     gf::gf_iszero,
     macros::sub,
-    params::{COND_BYTES, IRR_BYTES, SYND_BYTES, SYS_N, SYS_T},
+    params::{COND_BYTES, GFBITS, IRR_BYTES, SYND_BYTES, SYS_N, SYS_T},
     root::root,
     synd::synd,
     util::load_gf,
 };
 
-#[cfg(feature = "embedded-workspace")]
-struct DecryptWorkspace {
+/// Preallocated decapsulation workspace.
+///
+/// This holds all large temporary buffers used by Niederreiter decapsulation.
+/// Embedded callers can keep a single instance in long-lived memory and reuse
+/// it across operations, avoiding large stack allocations per call.
+///
+/// The support-generation scratch segment inside this workspace is treated as
+/// transient memory and scrubbed as part of the decapsulation flow.
+#[cfg_attr(docsrs, doc(cfg(feature = "embedded-workspace")))]
+pub struct DecapsulationWorkspace {
+    /// Expanded ciphertext bytes with trailing zero padding.
     r: [u8; SYS_N / 8],
+    /// Goppa polynomial coefficients derived from the secret key.
     g: [u16; SYS_T + 1],
+    /// Support set generated from Benes control bits.
     l: [u16; SYS_N],
+    /// Computed syndrome.
     s: [u16; SYS_T * 2],
+    /// Recomputed syndrome for verification.
     s_cmp: [u16; SYS_T * 2],
+    /// Error-locator polynomial.
     locator: [u16; SYS_T + 1],
+    /// Roots of the locator polynomial over support values.
     images: [u16; SYS_N],
+    /// Scratch storage used internally by support generation.
+    ///
+    /// This buffer is passed to `support_gen_with_scratch`, which clears it on
+    /// entry and scrubs it before return.
+    support_scratch: SupportGenScratch,
 }
 
-#[cfg(feature = "embedded-workspace")]
-static mut DECRYPT_WS: DecryptWorkspace = DecryptWorkspace {
-    r: [0u8; SYS_N / 8],
-    g: [0u16; SYS_T + 1],
-    l: [0u16; SYS_N],
-    s: [0u16; SYS_T * 2],
-    s_cmp: [0u16; SYS_T * 2],
-    locator: [0u16; SYS_T + 1],
-    images: [0u16; SYS_N],
-};
+impl DecapsulationWorkspace {
+    /// Create a zero-initialized workspace.
+    pub const fn new() -> Self {
+        Self {
+            r: [0u8; SYS_N / 8],
+            g: [0u16; SYS_T + 1],
+            l: [0u16; SYS_N],
+            s: [0u16; SYS_T * 2],
+            s_cmp: [0u16; SYS_T * 2],
+            locator: [0u16; SYS_T + 1],
+            images: [0u16; SYS_N],
+            support_scratch: [[0u8; (1 << GFBITS) / 8]; GFBITS],
+        }
+    }
 
-/// Niederreiter decryption with the Berlekamp decoder.
+    /// Overwrite all buffers in-place.
+    ///
+    /// Called before and after decapsulation to avoid stale sensitive
+    /// intermediates persisting in long-lived memory.
+    pub fn clear(&mut self) {
+        self.r.fill(0);
+        self.g.fill(0);
+        self.l.fill(0);
+        self.s.fill(0);
+        self.s_cmp.fill(0);
+        self.locator.fill(0);
+        self.images.fill(0);
+        for row in self.support_scratch.iter_mut() {
+            row.fill(0);
+        }
+    }
+}
+
+impl Default for DecapsulationWorkspace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Core decapsulation implementation that consumes a caller-provided workspace.
 ///
-/// It takes as input the secret key `sk` and a ciphertext `c`.
-/// It returns an error vector in `e` and the return value indicates success (0) or failure (1)
-pub(crate) fn decrypt(
+/// The workspace's support-generation scratch is used as temporary storage and
+/// is wiped by support-generation and by workspace clears at function boundaries.
+fn decrypt_with_workspace(
     e: &mut [u8; SYS_N / 8],
     sk: &[u8; IRR_BYTES + COND_BYTES],
     c: &[u8; SYND_BYTES],
+    workspace: &mut DecapsulationWorkspace,
 ) -> u8 {
+    // Start from a known clean state even when the caller reuses one
+    // long-lived workspace instance.
+    workspace.clear();
+    let DecapsulationWorkspace {
+        r,
+        g,
+        l,
+        s,
+        s_cmp,
+        locator,
+        images,
+        support_scratch,
+    } = workspace;
+
     let mut t: u16;
     let mut w: i32 = 0;
 
-    #[cfg(feature = "embedded-workspace")]
-    let (r, g, l, s, s_cmp, locator, images) = {
-        let ws = unsafe { &mut DECRYPT_WS };
-        (
-            &mut ws.r,
-            &mut ws.g,
-            &mut ws.l,
-            &mut ws.s,
-            &mut ws.s_cmp,
-            &mut ws.locator,
-            &mut ws.images,
-        )
-    };
-    #[cfg(feature = "embedded-workspace")]
-    {
-        r.fill(0);
-        g.fill(0);
-        l.fill(0);
-        s.fill(0);
-        s_cmp.fill(0);
-        locator.fill(0);
-        images.fill(0);
-    }
-
-    #[cfg(not(feature = "embedded-workspace"))]
-    let mut r = [0u8; SYS_N / 8];
-    #[cfg(not(feature = "embedded-workspace"))]
-    let mut g = [0u16; SYS_T + 1];
-    #[cfg(not(feature = "embedded-workspace"))]
-    let mut l = [0u16; SYS_N];
-    #[cfg(not(feature = "embedded-workspace"))]
-    let mut s = [0u16; SYS_T * 2];
-    #[cfg(not(feature = "embedded-workspace"))]
-    let mut s_cmp = [0u16; SYS_T * 2];
-    #[cfg(not(feature = "embedded-workspace"))]
-    let mut locator = [0u16; SYS_T + 1];
-    #[cfg(not(feature = "embedded-workspace"))]
-    let mut images = [0u16; SYS_N];
-    #[cfg(not(feature = "embedded-workspace"))]
-    let (r, g, l, s, s_cmp, locator, images) = (
-        &mut r,
-        &mut g,
-        &mut l,
-        &mut s,
-        &mut s_cmp,
-        &mut locator,
-        &mut images,
-    );
-
+    // Expand ciphertext to SYS_N bits by zero-padding bits beyond the
+    // syndrome length expected by Niederreiter decoding.
     r[..SYND_BYTES].copy_from_slice(&c[..SYND_BYTES]);
-
     r[SYND_BYTES..SYS_N / 8].fill(0);
 
+    // Load the Goppa polynomial from secret-key bytes and make it monic.
     for (i, chunk) in sk.chunks(2).take(SYS_T).enumerate() {
         g[i] = load_gf(sub!(chunk, 0, 2));
     }
     g[SYS_T] = 1;
 
-    support_gen(l, sub!(sk, IRR_BYTES, COND_BYTES));
+    // Build the support set from Benes control bits using caller-provided
+    // scratch to avoid hidden global mutable state.
+    support_gen_with_scratch(l, sub!(sk, IRR_BYTES, COND_BYTES), support_scratch);
 
+    // Classic Niederreiter decoding pipeline.
     synd(s, g, l, r);
-
     bm(locator, s);
-
     root(images, locator, l);
 
-    e[0..SYS_N / 8].fill(0);
+    e.fill(0);
 
+    // Each zero root corresponds to an error position. Weight is accumulated
+    // for the final validity check.
     for i in 0..SYS_N {
         t = gf_iszero(images[i]) & 1;
 
@@ -120,6 +139,9 @@ pub(crate) fn decrypt(
         w += t as i32;
     }
 
+    // Recompute syndrome from recovered error vector and compare against the
+    // original one. Combined with the exact-weight check this determines
+    // whether decoding succeeded.
     synd(s_cmp, g, l, e);
 
     let mut check = w as u16;
@@ -129,10 +151,42 @@ pub(crate) fn decrypt(
         check |= s[i] ^ s_cmp[i];
     }
 
+    // Map "all checks passed" to 0 and failure to 1 without branches.
     check = check.wrapping_sub(1);
     check >>= 15;
 
-    (check ^ 1) as u8
+    let result = (check ^ 1) as u8;
+
+    // Clear sensitive intermediates before returning to the caller.
+    workspace.clear();
+    result
+}
+
+/// Niederreiter decryption with the Berlekamp decoder.
+///
+/// Non-embedded entry point that allocates a workspace on the stack.
+#[cfg(not(feature = "embedded-workspace"))]
+pub(crate) fn decrypt(
+    e: &mut [u8; SYS_N / 8],
+    sk: &[u8; IRR_BYTES + COND_BYTES],
+    c: &[u8; SYND_BYTES],
+) -> u8 {
+    let mut workspace = DecapsulationWorkspace::new();
+    decrypt_with_workspace(e, sk, c, &mut workspace)
+}
+
+/// Niederreiter decryption with caller-managed workspace.
+///
+/// Embedded callers should use this entry point to reuse a single workspace
+/// across invocations and avoid large per-call stack frames.
+#[cfg(feature = "embedded-workspace")]
+pub(crate) fn decrypt(
+    e: &mut [u8; SYS_N / 8],
+    sk: &[u8; IRR_BYTES + COND_BYTES],
+    c: &[u8; SYND_BYTES],
+    workspace: &mut DecapsulationWorkspace,
+) -> u8 {
+    decrypt_with_workspace(e, sk, c, workspace)
 }
 
 #[cfg(test)]
@@ -150,11 +204,24 @@ mod tests {
         let mut actual_error_vector = [0u8; 1 + SYS_N / 8];
         actual_error_vector[0] = 2;
 
-        decrypt(
-            sub!(mut actual_error_vector, 1, SYS_N / 8),
-            sub!(sk, 40, IRR_BYTES + COND_BYTES),
-            sub!(mut c, 0, SYND_BYTES),
-        );
+        #[cfg(feature = "embedded-workspace")]
+        {
+            let mut workspace = DecapsulationWorkspace::new();
+            decrypt(
+                sub!(mut actual_error_vector, 1, SYS_N / 8),
+                sub!(sk, 40, IRR_BYTES + COND_BYTES),
+                sub!(mut c, 0, SYND_BYTES),
+                &mut workspace,
+            );
+        }
+        #[cfg(not(feature = "embedded-workspace"))]
+        {
+            decrypt(
+                sub!(mut actual_error_vector, 1, SYS_N / 8),
+                sub!(sk, 40, IRR_BYTES + COND_BYTES),
+                sub!(mut c, 0, SYND_BYTES),
+            );
+        }
 
         assert_eq!(
             &actual_error_vector[1..SYS_N / 8],

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -11,6 +11,28 @@ use crate::{
     util::load_gf,
 };
 
+#[cfg(feature = "embedded-workspace")]
+struct DecryptWorkspace {
+    r: [u8; SYS_N / 8],
+    g: [u16; SYS_T + 1],
+    l: [u16; SYS_N],
+    s: [u16; SYS_T * 2],
+    s_cmp: [u16; SYS_T * 2],
+    locator: [u16; SYS_T + 1],
+    images: [u16; SYS_N],
+}
+
+#[cfg(feature = "embedded-workspace")]
+static mut DECRYPT_WS: DecryptWorkspace = DecryptWorkspace {
+    r: [0u8; SYS_N / 8],
+    g: [0u16; SYS_T + 1],
+    l: [0u16; SYS_N],
+    s: [0u16; SYS_T * 2],
+    s_cmp: [0u16; SYS_T * 2],
+    locator: [0u16; SYS_T + 1],
+    images: [0u16; SYS_N],
+};
+
 /// Niederreiter decryption with the Berlekamp decoder.
 ///
 /// It takes as input the secret key `sk` and a ciphertext `c`.
@@ -23,15 +45,54 @@ pub(crate) fn decrypt(
     let mut t: u16;
     let mut w: i32 = 0;
 
+    #[cfg(feature = "embedded-workspace")]
+    let (r, g, l, s, s_cmp, locator, images) = {
+        let ws = unsafe { &mut DECRYPT_WS };
+        (
+            &mut ws.r,
+            &mut ws.g,
+            &mut ws.l,
+            &mut ws.s,
+            &mut ws.s_cmp,
+            &mut ws.locator,
+            &mut ws.images,
+        )
+    };
+    #[cfg(feature = "embedded-workspace")]
+    {
+        r.fill(0);
+        g.fill(0);
+        l.fill(0);
+        s.fill(0);
+        s_cmp.fill(0);
+        locator.fill(0);
+        images.fill(0);
+    }
+
+    #[cfg(not(feature = "embedded-workspace"))]
     let mut r = [0u8; SYS_N / 8];
-
+    #[cfg(not(feature = "embedded-workspace"))]
     let mut g = [0u16; SYS_T + 1];
+    #[cfg(not(feature = "embedded-workspace"))]
     let mut l = [0u16; SYS_N];
-
+    #[cfg(not(feature = "embedded-workspace"))]
     let mut s = [0u16; SYS_T * 2];
+    #[cfg(not(feature = "embedded-workspace"))]
     let mut s_cmp = [0u16; SYS_T * 2];
+    #[cfg(not(feature = "embedded-workspace"))]
     let mut locator = [0u16; SYS_T + 1];
+    #[cfg(not(feature = "embedded-workspace"))]
     let mut images = [0u16; SYS_N];
+    #[cfg(not(feature = "embedded-workspace"))]
+    let (r, g, l, s, s_cmp, locator, images) = (
+        &mut r,
+        &mut g,
+        &mut l,
+        &mut s,
+        &mut s_cmp,
+        &mut locator,
+        &mut images,
+    );
 
     r[..SYND_BYTES].copy_from_slice(&c[..SYND_BYTES]);
 
@@ -42,13 +103,13 @@ pub(crate) fn decrypt(
     }
     g[SYS_T] = 1;
 
-    support_gen(&mut l, sub!(sk, IRR_BYTES, COND_BYTES));
+    support_gen(l, sub!(sk, IRR_BYTES, COND_BYTES));
 
-    synd(&mut s, &g, &l, &r);
+    synd(s, g, l, r);
 
-    bm(&mut locator, &mut s);
+    bm(locator, s);
 
-    root(&mut images, &locator, &l);
+    root(images, locator, l);
 
     e[0..SYS_N / 8].fill(0);
 
@@ -59,7 +120,7 @@ pub(crate) fn decrypt(
         w += t as i32;
     }
 
-    synd(&mut s_cmp, &g, &l, e);
+    synd(s_cmp, g, l, e);
 
     let mut check = w as u16;
     check ^= SYS_T as u16;

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -241,7 +241,6 @@ fn syndrome(
     let _ = syndrome_core::<_, { HAS_TAIL }, false>(s, e, &mut reader);
 }
 
-
 /// Encryption routine.
 /// Takes a public key `pk` to compute error vector `e` and syndrome `s`.
 pub(crate) fn encrypt<R: CryptoRng + RngCore>(
@@ -260,11 +259,11 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng};
 
     use crate::api::{CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES};
-    use crate::test_utils::{generate_public_key_bytes, SliceReader};
     #[cfg(feature = "mceliece8192128f")]
     use crate::nist_aes_rng::AesState;
     #[cfg(feature = "mceliece8192128f")]
     use crate::test_utils::TestData;
+    use crate::test_utils::{generate_public_key_bytes, SliceReader};
 
     #[test]
     fn test_encrypt_from_reader_matches_encrypt() {
@@ -285,8 +284,13 @@ mod tests {
         );
 
         let mut reader = SliceReader { data: &pk, pos: 0 };
-        crate::streaming::encrypt_from_reader(&mut c_reader, &mut reader, &mut e_reader, &mut rng_reader)
-            .unwrap();
+        crate::streaming::encrypt_from_reader(
+            &mut c_reader,
+            &mut reader,
+            &mut e_reader,
+            &mut rng_reader,
+        )
+        .unwrap();
 
         assert_eq!(reader.pos, CRYPTO_PUBLICKEYBYTES);
         assert_eq!(e_direct, e_reader);

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -8,6 +8,14 @@ use crate::{
 };
 use rand::{CryptoRng, RngCore};
 
+pub(crate) trait RowReader {
+    type Error;
+
+    fn read_row(&mut self, row: &mut [u8]) -> Result<(), Self::Error>;
+    fn finish(&mut self) -> Result<(), Self::Error>;
+    fn invalid_padding(&self) -> Self::Error;
+}
+
 /// Takes two 16-bit integers and determines whether they are equal (u8::MAX) or different (0)
 fn same_mask_u8(x: u16, y: u16) -> u8 {
     let mut mask = (x ^ y) as u32;
@@ -22,7 +30,7 @@ fn same_mask_u8(x: u16, y: u16) -> u8 {
 /// Does not take any input arguments.
 /// If generation of pseudo-random numbers fails, an error is returned.
 #[cfg(not(any(feature = "mceliece8192128", feature = "mceliece8192128f")))]
-fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8; SYS_N / 8], rng: &mut R) {
+pub(crate) fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8; SYS_N / 8], rng: &mut R) {
     let mut ind = [0u16; SYS_T];
     let mut val = [0u8; SYS_T];
 
@@ -88,7 +96,7 @@ fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8; SYS_N / 8], rng: &mut R) {
 /// Does not take any input arguments.
 /// If generation of pseudo-random numbers fails, an error is returned.
 #[cfg(any(feature = "mceliece8192128", feature = "mceliece8192128f"))]
-fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8], rng: &mut R) {
+pub(crate) fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8], rng: &mut R) {
     let mut ind = [0u16; SYS_T];
     let mut bytes = [0u8; SYS_T * 2];
     let mut val = [0u8; SYS_T];
@@ -135,28 +143,38 @@ fn gen_e<R: CryptoRng + RngCore>(e: &mut [u8], rng: &mut R) {
 /// Syndrome computation.
 ///
 /// Computes syndrome `s` based on public key `pk` and error vector `e`.
-#[cfg(any(feature = "mceliece6960119", feature = "mceliece6960119f"))]
-fn syndrome(
-    s: &mut [u8; (PK_NROWS + 7) / 8],
-    pk: &[u8; PK_NROWS * PK_ROW_BYTES],
+///
+/// Note: `RowReader` is a generic trait (no dynamic dispatch). Release asm
+/// checks for the examples showed no out-of-line symbols/calls for these
+/// methods; they inline away.
+pub(crate) fn syndrome_core<R, const HAS_TAIL: bool, const CHECK_PADDING: bool>(
+    s: &mut [u8; PK_NROWS.div_ceil(8)],
     e: &[u8; SYS_N / 8],
-) {
+    reader: &mut R,
+) -> Result<(), R::Error>
+where
+    R: RowReader,
+{
     let mut row = [0u8; SYS_N / 8];
-
-    let mut pk_segment = &pk[..];
     let tail = PK_NROWS % 8;
+    let mut padding_or = 0u8;
 
     s[0..SYND_BYTES].fill(0);
 
     for i in 0..PK_NROWS {
-        row[0..SYS_N / 8].fill(0);
+        row.fill(0);
 
-        for j in 0..PK_ROW_BYTES {
-            row[SYS_N / 8 - PK_ROW_BYTES + j] = pk_segment[j];
+        let row_bytes = &mut row[SYS_N / 8 - PK_ROW_BYTES..];
+        reader.read_row(row_bytes)?;
+
+        if CHECK_PADDING {
+            padding_or |= row_bytes[PK_ROW_BYTES - 1];
         }
 
-        for j in ((SYS_N / 8 - PK_ROW_BYTES)..SYS_N / 8).rev() {
-            row[j] = (row[j] << tail) | (row[j - 1] >> (8 - tail));
+        if HAS_TAIL {
+            for j in ((SYS_N / 8 - PK_ROW_BYTES)..SYS_N / 8).rev() {
+                row[j] = (row[j] << tail) | (row[j - 1] >> (8 - tail));
+            }
         }
 
         row[i / 8] |= 1 << (i % 8);
@@ -172,50 +190,57 @@ fn syndrome(
         b &= 1;
 
         s[i / 8] |= b << (i % 8);
-
-        pk_segment = &pk_segment[PK_ROW_BYTES..];
     }
+
+    reader.finish()?;
+
+    if CHECK_PADDING {
+        if (padding_or >> (crate::params::PK_NCOLS % 8)) != 0 {
+            return Err(reader.invalid_padding());
+        }
+    }
+
+    Ok(())
 }
 
 /// Syndrome computation.
 ///
 /// Computes syndrome `s` based on public key `pk` and error vector `e`.
-#[cfg(not(any(feature = "mceliece6960119", feature = "mceliece6960119f")))]
 fn syndrome(
     s: &mut [u8; PK_NROWS.div_ceil(8)],
     pk: &[u8; PK_NROWS * PK_ROW_BYTES],
     e: &[u8; SYS_N / 8],
 ) {
-    let mut row = [0u8; SYS_N / 8];
+    const HAS_TAIL: bool = PK_NROWS % 8 != 0;
 
-    let mut pk_segment = &pk[..];
-
-    s[0..SYND_BYTES].fill(0);
-
-    for i in 0..PK_NROWS {
-        row[0..SYS_N / 8].fill(0);
-
-        for j in 0..PK_ROW_BYTES {
-            row[SYS_N / 8 - PK_ROW_BYTES + j] = pk_segment[j];
-        }
-
-        row[i / 8] |= 1 << (i % 8);
-
-        let mut b = 0u8;
-        for j in 0..SYS_N / 8 {
-            b ^= row[j] & e[j];
-        }
-
-        b ^= b >> 4;
-        b ^= b >> 2;
-        b ^= b >> 1;
-        b &= 1;
-
-        s[i / 8] |= b << (i % 8);
-
-        pk_segment = &pk_segment[PK_ROW_BYTES..];
+    struct PkSliceRows<'a> {
+        pk: &'a [u8; PK_NROWS * PK_ROW_BYTES],
+        offset: usize,
     }
+
+    impl<'a> RowReader for PkSliceRows<'a> {
+        type Error = ();
+
+        fn read_row(&mut self, row: &mut [u8]) -> Result<(), Self::Error> {
+            let end = self.offset + PK_ROW_BYTES;
+            row.copy_from_slice(&self.pk[self.offset..end]);
+            self.offset = end;
+            Ok(())
+        }
+
+        fn finish(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn invalid_padding(&self) -> Self::Error {
+            unreachable!()
+        }
+    }
+
+    let mut reader = PkSliceRows { pk, offset: 0 };
+    let _ = syndrome_core::<_, { HAS_TAIL }, false>(s, e, &mut reader);
 }
+
 
 /// Encryption routine.
 /// Takes a public key `pk` to compute error vector `e` and syndrome `s`.
@@ -231,16 +256,42 @@ pub(crate) fn encrypt<R: CryptoRng + RngCore>(
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "mceliece8192128f")]
     use super::*;
-    #[cfg(feature = "mceliece8192128f")]
-    use crate::api::CRYPTO_CIPHERTEXTBYTES;
-    #[cfg(feature = "mceliece8192128f")]
-    use crate::api::CRYPTO_PUBLICKEYBYTES;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    use crate::api::{CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES};
+    use crate::test_utils::{generate_public_key_bytes, SliceReader};
     #[cfg(feature = "mceliece8192128f")]
     use crate::nist_aes_rng::AesState;
     #[cfg(feature = "mceliece8192128f")]
     use crate::test_utils::TestData;
+
+    #[test]
+    fn test_encrypt_from_reader_matches_encrypt() {
+        let pk = generate_public_key_bytes([0x42; 32]);
+        let mut c_direct = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let mut c_reader = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let mut e_direct = [0u8; SYS_N / 8];
+        let mut e_reader = [0u8; SYS_N / 8];
+
+        let mut rng_direct = StdRng::from_seed([0x24; 32]);
+        let mut rng_reader = StdRng::from_seed([0x24; 32]);
+
+        encrypt(
+            &mut c_direct,
+            sub!(pk, 0, CRYPTO_PUBLICKEYBYTES),
+            &mut e_direct,
+            &mut rng_direct,
+        );
+
+        let mut reader = SliceReader { data: &pk, pos: 0 };
+        crate::streaming::encrypt_from_reader(&mut c_reader, &mut reader, &mut e_reader, &mut rng_reader)
+            .unwrap();
+
+        assert_eq!(reader.pos, CRYPTO_PUBLICKEYBYTES);
+        assert_eq!(e_direct, e_reader);
+        assert_eq!(c_direct, c_reader);
+    }
 
     #[test]
     #[cfg(feature = "mceliece8192128f")]
@@ -274,6 +325,44 @@ mod tests {
             &mut rng_state,
         );
 
+        assert_eq!(compare_ct, c);
+    }
+
+    #[test]
+    #[cfg(feature = "mceliece8192128f")]
+    fn test_encrypt_from_reader() {
+        let entropy_input = [
+            6, 21, 80, 35, 77, 21, 140, 94, 201, 85, 149, 254, 4, 239, 122, 37, 118, 127, 46, 36,
+            204, 43, 196, 121, 208, 157, 134, 220, 154, 188, 253, 231, 5, 106, 140, 38, 111, 158,
+            249, 126, 208, 133, 65, 219, 210, 225, 255, 161,
+        ];
+
+        let mut rng_state = AesState::new();
+        rng_state.randombytes_init(entropy_input);
+
+        let mut second_seed = [0u8; 33];
+        second_seed[0] = 64;
+
+        rng_state.fill_bytes(&mut second_seed[1..]);
+
+        let mut e = [0u8; SYS_N / 8];
+
+        let mut c = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let pk = TestData::new().u8vec("mceliece8192128f_pk1");
+
+        let compare_ct = TestData::new().u8vec("mceliece8192128f_encrypt_ct");
+        assert_eq!(compare_ct.len(), CRYPTO_CIPHERTEXTBYTES);
+
+        let mut reader = SliceReader { data: &pk, pos: 0 };
+        crate::streaming::encrypt_from_reader(
+            &mut c,
+            &mut reader,
+            sub!(mut e, 0, SYS_N / 8),
+            &mut rng_state,
+        )
+        .unwrap();
+
+        assert_eq!(reader.pos, CRYPTO_PUBLICKEYBYTES);
         assert_eq!(compare_ct, c);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "embedded-workspace"), forbid(unsafe_code))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod api;
@@ -25,6 +25,7 @@ mod test_utils;
 mod transpose;
 mod uint64_sort;
 mod util;
+pub mod streaming;
 
 use core::fmt::Debug;
 use rand::{CryptoRng, RngCore};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
-#![cfg_attr(not(feature = "embedded-workspace"), forbid(unsafe_code))]
+#![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod api;
@@ -18,6 +18,7 @@ mod params;
 mod pk_gen;
 mod root;
 mod sk_gen;
+pub mod streaming;
 mod synd;
 mod test_katkem;
 mod test_kem;
@@ -25,7 +26,6 @@ mod test_utils;
 mod transpose;
 mod uint64_sort;
 mod util;
-pub mod streaming;
 
 use core::fmt::Debug;
 use rand::{CryptoRng, RngCore};
@@ -42,6 +42,8 @@ pub use api::{
     CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PRIMITIVE, CRYPTO_PUBLICKEYBYTES,
     CRYPTO_SECRETKEYBYTES,
 };
+#[cfg(feature = "embedded-workspace")]
+pub use decrypt::DecapsulationWorkspace;
 
 mod macros {
     /// This macro(A, B, C, T) allows to get “&A[B..B+C]” of type “&[T]” as type “&[T; C]”.
@@ -408,6 +410,7 @@ pub fn encapsulate_boxed<R: CryptoRng + RngCore>(
 ///
 /// Given a secret key `secret_key` and a ciphertext `ciphertext`,
 /// determine the shared key negotiated by both parties.
+#[cfg(not(feature = "embedded-workspace"))]
 pub fn decapsulate<'shared_secret>(
     ciphertext: &Ciphertext,
     secret_key: &SecretKey,
@@ -424,9 +427,35 @@ pub fn decapsulate<'shared_secret>(
     SharedSecret(shared_secret_buf)
 }
 
+/// KEM Decapsulation.
+///
+/// Embedded targets should pass a reusable [`DecapsulationWorkspace`] to avoid
+/// large stack allocations and to keep decapsulation reentrant.
+///
+/// The workspace internals (including support-generation scratch) are used as
+/// ephemeral state and are scrubbed by the decapsulation flow.
+#[cfg(feature = "embedded-workspace")]
+pub fn decapsulate<'shared_secret>(
+    ciphertext: &Ciphertext,
+    secret_key: &SecretKey,
+    shared_secret_buf: &'shared_secret mut [u8; CRYPTO_BYTES],
+    workspace: &mut DecapsulationWorkspace,
+) -> SharedSecret<'shared_secret> {
+    let mut shared_secret_buf = KeyBufferMut::Borrowed(shared_secret_buf);
+
+    operations::crypto_kem_dec(
+        shared_secret_buf.as_mut(),
+        ciphertext.as_array(),
+        secret_key.as_array(),
+        workspace,
+    );
+
+    SharedSecret(shared_secret_buf)
+}
+
 /// Convenient wrapper around [`decapsulate`] that stores the shared secret on the heap
 /// and returns it with the ``'static`` lifetime.
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "embedded-workspace")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub fn decapsulate_boxed(ciphertext: &Ciphertext, secret_key: &SecretKey) -> SharedSecret<'static> {
     let mut shared_secret_buf = KeyBufferMut::Owned(Box::new([0u8; CRYPTO_BYTES]));
@@ -435,6 +464,29 @@ pub fn decapsulate_boxed(ciphertext: &Ciphertext, secret_key: &SecretKey) -> Sha
         shared_secret_buf.as_mut(),
         ciphertext.as_array(),
         secret_key.as_array(),
+    );
+
+    SharedSecret(shared_secret_buf)
+}
+
+/// Convenient wrapper around [`decapsulate`] for heap-backed shared secret.
+///
+/// Workspace internals are treated as temporary state and scrubbed during
+/// decapsulation.
+#[cfg(all(feature = "alloc", feature = "embedded-workspace"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+pub fn decapsulate_boxed(
+    ciphertext: &Ciphertext,
+    secret_key: &SecretKey,
+    workspace: &mut DecapsulationWorkspace,
+) -> SharedSecret<'static> {
+    let mut shared_secret_buf = KeyBufferMut::Owned(Box::new([0u8; CRYPTO_BYTES]));
+
+    operations::crypto_kem_dec(
+        shared_secret_buf.as_mut(),
+        ciphertext.as_array(),
+        secret_key.as_array(),
+        workspace,
     );
 
     SharedSecret(shared_secret_buf)
@@ -511,11 +563,24 @@ mod kem_api {
                 .try_into()
                 .expect("GenericArray should be CRYPTO_BYTES long");
 
+            #[cfg(not(feature = "embedded-workspace"))]
             crate::operations::crypto_kem_dec(
                 shared_secret_buf,
                 ciphertext.as_array(),
                 self.as_array(),
             );
+            #[cfg(feature = "embedded-workspace")]
+            {
+                // KEM trait signatures cannot carry an external workspace.
+                // For this trait adapter we allocate a local one.
+                let mut workspace = crate::decrypt::DecapsulationWorkspace::new();
+                crate::operations::crypto_kem_dec(
+                    shared_secret_buf,
+                    ciphertext.as_array(),
+                    self.as_array(),
+                    &mut workspace,
+                );
+            }
             Ok(SharedSecret::<Ciphertext>::new(shared_secret))
         }
     }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -7,6 +7,7 @@ use crate::{
     api::{CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES},
     crypto_hash::shake256,
     decrypt::decrypt,
+    decrypt::DecapsulationWorkspace,
     encrypt::encrypt,
     macros::sub,
     params::{COND_BYTES, GFBITS, IRR_BYTES, SYND_BYTES, SYS_N, SYS_T},
@@ -109,33 +110,53 @@ pub(crate) fn crypto_kem_enc<R: CryptoRng + RngCore>(
 /// Given a secret key `sk` and a ciphertext `c`,
 /// determine the shared text `key` negotiated by both parties.
 #[cfg(not(any(feature = "mceliece6960119", feature = "mceliece6960119f")))]
-pub(crate) fn crypto_kem_dec(
+fn crypto_kem_dec_core(
     key: &mut [u8; CRYPTO_BYTES],
     c: &[u8; CRYPTO_CIPHERTEXTBYTES],
     sk: &[u8; CRYPTO_SECRETKEYBYTES],
+    workspace: &mut DecapsulationWorkspace,
 ) -> u8 {
-    let mut e = [0u8; SYS_N / 8];
+    #[cfg(not(feature = "embedded-workspace"))]
+    let _ = workspace;
 
+    let mut e = [0u8; SYS_N / 8];
     let mut preimage = [0u8; 1 + SYS_N / 8 + SYND_BYTES];
 
+    // Decryption consumes the caller-provided workspace. For embedded targets
+    // this avoids thread-unsafe global mutable state.
+    #[cfg(feature = "embedded-workspace")]
+    let ret_decrypt: u8 = decrypt(
+        sub!(mut e, 0, SYS_N / 8),
+        sub!(sk, 40, IRR_BYTES + COND_BYTES),
+        sub!(c, 0, SYND_BYTES),
+        workspace,
+    );
+    // Non-embedded builds use the stack-allocating decrypt entry point.
+    #[cfg(not(feature = "embedded-workspace"))]
     let ret_decrypt: u8 = decrypt(
         sub!(mut e, 0, SYS_N / 8),
         sub!(sk, 40, IRR_BYTES + COND_BYTES),
         sub!(c, 0, SYND_BYTES),
     );
 
+    // Convert decrypt return value (0=success, 1=failure) into mask:
+    // success -> 0xFFFF, failure -> 0x0000.
     let mut m = ret_decrypt as u16;
     m = m.wrapping_sub(1);
     m >>= 8;
 
+    // Domain-separation byte for the KDF preimage.
     preimage[0] = (m & 1) as u8;
 
     let s = &sk[40 + IRR_BYTES + COND_BYTES..];
 
+    // On success, use decoded error vector e; on failure, use fallback secret s.
+    // Selection is branch-free to avoid leaking decoder outcome.
     for i in 0..SYS_N / 8 {
         preimage[1 + i] = (!m as u8 & s[i]) | (m as u8 & e[i]);
     }
 
+    // Ciphertext prefix is always included in the KDF preimage.
     (&mut preimage[1 + (SYS_N / 8)..])[0..SYND_BYTES].copy_from_slice(&c[0..SYND_BYTES]);
 
     shake256(&mut key[0..32], &preimage);
@@ -148,40 +169,60 @@ pub(crate) fn crypto_kem_dec(
 /// Given a secret key `sk` and a ciphertext `c`,
 /// determine the shared text `key` negotiated by both parties.
 #[cfg(any(feature = "mceliece6960119", feature = "mceliece6960119f"))]
-pub(crate) fn crypto_kem_dec(
+fn crypto_kem_dec_core(
     key: &mut [u8; CRYPTO_BYTES],
     c: &[u8; CRYPTO_CIPHERTEXTBYTES],
     sk: &[u8; CRYPTO_SECRETKEYBYTES],
+    workspace: &mut DecapsulationWorkspace,
 ) -> u8 {
+    #[cfg(not(feature = "embedded-workspace"))]
+    let _ = workspace;
+
     let mut e = [0u8; SYS_N / 8];
 
     let mut preimage = [0u8; 1 + SYS_N / 8 + SYND_BYTES];
 
+    // For parameter sets with non-byte-aligned syndrome size, verify that
+    // higher padding bits are zero.
     let padding_ok = check_c_padding(sub!(c, 0, SYND_BYTES));
 
+    #[cfg(feature = "embedded-workspace")]
+    let ret_decrypt: u8 = decrypt(
+        sub!(mut e, 0, SYS_N / 8),
+        sub!(sk, 40, IRR_BYTES + COND_BYTES),
+        sub!(c, 0, SYND_BYTES),
+        workspace,
+    );
+    #[cfg(not(feature = "embedded-workspace"))]
     let ret_decrypt: u8 = decrypt(
         sub!(mut e, 0, SYS_N / 8),
         sub!(sk, 40, IRR_BYTES + COND_BYTES),
         sub!(c, 0, SYND_BYTES),
     );
 
+    // Convert decrypt return value (0=success, 1=failure) into mask:
+    // success -> 0xFFFF, failure -> 0x0000.
     let mut m = ret_decrypt as u16;
     m = m.wrapping_sub(1);
     m >>= 8;
 
+    // Domain-separation byte for the KDF preimage.
     preimage[0] = (m & 1) as u8;
 
     let s = &sk[40 + IRR_BYTES + COND_BYTES..];
 
+    // On success, use decoded error vector e; on failure, use fallback secret s.
+    // Selection is branch-free to avoid leaking decoder outcome.
     for i in 0..SYS_N / 8 {
         preimage[1 + i] = (!m as u8 & s[i]) | (m as u8 & e[i]);
     }
 
+    // Ciphertext prefix is always included in the KDF preimage.
     (&mut preimage[1 + (SYS_N / 8)..])[0..SYND_BYTES].copy_from_slice(&c[0..SYND_BYTES]);
 
     shake256(&mut key[0..32], &preimage);
 
-    // clear outputs (set to all 1's) if padding bits are not all zero
+    // Invalidate key material if ciphertext padding is malformed.
 
     let mask = padding_ok;
 
@@ -190,6 +231,70 @@ pub(crate) fn crypto_kem_dec(
     }
 
     padding_ok
+}
+
+/// KEM Decapsulation.
+///
+/// Non-embedded path: allocate workspace on stack per call.
+#[cfg(all(
+    not(feature = "embedded-workspace"),
+    not(any(feature = "mceliece6960119", feature = "mceliece6960119f"))
+))]
+pub(crate) fn crypto_kem_dec(
+    key: &mut [u8; CRYPTO_BYTES],
+    c: &[u8; CRYPTO_CIPHERTEXTBYTES],
+    sk: &[u8; CRYPTO_SECRETKEYBYTES],
+) -> u8 {
+    let mut workspace = DecapsulationWorkspace::new();
+    crypto_kem_dec_core(key, c, sk, &mut workspace)
+}
+
+/// KEM Decapsulation with caller-managed workspace.
+///
+/// Embedded path: the caller owns workspace memory and can reuse it.
+#[cfg(all(
+    feature = "embedded-workspace",
+    not(any(feature = "mceliece6960119", feature = "mceliece6960119f"))
+))]
+pub(crate) fn crypto_kem_dec(
+    key: &mut [u8; CRYPTO_BYTES],
+    c: &[u8; CRYPTO_CIPHERTEXTBYTES],
+    sk: &[u8; CRYPTO_SECRETKEYBYTES],
+    workspace: &mut DecapsulationWorkspace,
+) -> u8 {
+    crypto_kem_dec_core(key, c, sk, workspace)
+}
+
+/// KEM Decapsulation.
+///
+/// Non-embedded path for padding-checked variants.
+#[cfg(all(
+    not(feature = "embedded-workspace"),
+    any(feature = "mceliece6960119", feature = "mceliece6960119f")
+))]
+pub(crate) fn crypto_kem_dec(
+    key: &mut [u8; CRYPTO_BYTES],
+    c: &[u8; CRYPTO_CIPHERTEXTBYTES],
+    sk: &[u8; CRYPTO_SECRETKEYBYTES],
+) -> u8 {
+    let mut workspace = DecapsulationWorkspace::new();
+    crypto_kem_dec_core(key, c, sk, &mut workspace)
+}
+
+/// KEM Decapsulation with caller-managed workspace.
+///
+/// Embedded path for padding-checked variants.
+#[cfg(all(
+    feature = "embedded-workspace",
+    any(feature = "mceliece6960119", feature = "mceliece6960119f")
+))]
+pub(crate) fn crypto_kem_dec(
+    key: &mut [u8; CRYPTO_BYTES],
+    c: &[u8; CRYPTO_CIPHERTEXTBYTES],
+    sk: &[u8; CRYPTO_SECRETKEYBYTES],
+    workspace: &mut DecapsulationWorkspace,
+) -> u8 {
+    crypto_kem_dec_core(key, c, sk, workspace)
 }
 
 /// KEM Keypair generation.
@@ -335,8 +440,8 @@ pub(crate) fn crypto_kem_keypair<R: CryptoRng + RngCore>(
 mod tests {
     use super::*;
     use crate::nist_aes_rng::AesState;
-    use crate::test_utils::TestData;
     use crate::test_utils::SliceReader;
+    use crate::test_utils::TestData;
     use std::convert::TryFrom;
 
     #[test]
@@ -348,11 +453,24 @@ mod tests {
         let mut test_key = [0u8; 32];
         let compare_key = TestData::new().u8vec("mceliece8192128f_operations_ss");
 
-        crypto_kem_dec(
-            &mut test_key,
-            sub!(mut c, 0, CRYPTO_CIPHERTEXTBYTES),
-            sub!(mut sk, 0, CRYPTO_SECRETKEYBYTES),
-        );
+        #[cfg(feature = "embedded-workspace")]
+        {
+            let mut workspace = DecapsulationWorkspace::new();
+            crypto_kem_dec(
+                &mut test_key,
+                sub!(mut c, 0, CRYPTO_CIPHERTEXTBYTES),
+                sub!(mut sk, 0, CRYPTO_SECRETKEYBYTES),
+                &mut workspace,
+            );
+        }
+        #[cfg(not(feature = "embedded-workspace"))]
+        {
+            crypto_kem_dec(
+                &mut test_key,
+                sub!(mut c, 0, CRYPTO_CIPHERTEXTBYTES),
+                sub!(mut sk, 0, CRYPTO_SECRETKEYBYTES),
+            );
+        }
 
         assert_eq!(test_key, compare_key.as_slice());
     }
@@ -470,8 +588,8 @@ mod tests {
 #[cfg(test)]
 mod streaming_tests {
     use super::*;
-    use rand::{rngs::StdRng, SeedableRng};
     use crate::test_utils::{generate_public_key_bytes, SliceReader};
+    use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
     fn test_crypto_kem_enc_from_reader_matches_enc() {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -16,6 +16,19 @@ use crate::{
 };
 use rand::{CryptoRng, RngCore};
 
+pub(crate) fn derive_ss_from_e_and_c(
+    key: &mut [u8; CRYPTO_BYTES],
+    e: &[u8; SYS_N / 8],
+    c: &[u8; SYND_BYTES],
+) {
+    let mut one_ec = [0u8; 1 + SYS_N / 8 + SYND_BYTES];
+    one_ec[0] = 1;
+    one_ec[1..1 + SYS_N / 8].copy_from_slice(&e[..SYS_N / 8]);
+    one_ec[1 + SYS_N / 8..1 + SYS_N / 8 + SYND_BYTES].copy_from_slice(c);
+
+    shake256(&mut key[0..32], &one_ec);
+}
+
 /// This function determines (in a constant-time manner) whether the padding bits of `pk` are all zero.
 #[cfg(any(feature = "mceliece6960119", feature = "mceliece6960119f"))]
 fn check_pk_padding(pk: &[u8; PK_NROWS * PK_ROW_BYTES]) -> u8 {
@@ -53,15 +66,8 @@ pub(crate) fn crypto_kem_enc<R: CryptoRng + RngCore>(
 ) {
     let mut e = [0u8; SYS_N / 8];
 
-    let mut one_ec = [0u8; 1 + SYS_N / 8 + SYND_BYTES];
-    one_ec[0] = 1;
-
     encrypt(c, pk, sub!(mut e, 0, SYS_N / 8), rng);
-
-    one_ec[1..1 + SYS_N / 8].copy_from_slice(&e[..SYS_N / 8]);
-    one_ec[1 + SYS_N / 8..1 + SYS_N / 8 + SYND_BYTES].copy_from_slice(&c[0..SYND_BYTES]);
-
-    shake256(&mut key[0..32], &one_ec);
+    derive_ss_from_e_and_c(key, &e, sub!(c, 0, SYND_BYTES));
 }
 
 /// KEM Encapsulation.
@@ -78,17 +84,10 @@ pub(crate) fn crypto_kem_enc<R: CryptoRng + RngCore>(
 ) -> u8 {
     let mut e = [0u8; SYS_N / 8];
 
-    let mut one_ec = [0u8; 1 + SYS_N / 8 + SYND_BYTES];
-    one_ec[0] = 1;
-
     let padding_ok = check_pk_padding(pk);
 
     encrypt(c, pk, sub!(mut e, 0, SYS_N / 8), rng);
-
-    one_ec[1..1 + (SYS_N / 8)].copy_from_slice(&e[..SYS_N / 8]);
-    one_ec[1 + (SYS_N / 8)..1 + (SYS_N / 8) + SYND_BYTES].copy_from_slice(&c[0..SYND_BYTES]);
-
-    shake256(&mut key[0..32], &one_ec);
+    derive_ss_from_e_and_c(key, &e, sub!(c, 0, SYND_BYTES));
 
     // clear outputs (set to all 0's) if padding bits are not all zero
 
@@ -337,6 +336,7 @@ mod tests {
     use super::*;
     use crate::nist_aes_rng::AesState;
     use crate::test_utils::TestData;
+    use crate::test_utils::SliceReader;
     use std::convert::TryFrom;
 
     #[test]
@@ -398,6 +398,42 @@ mod tests {
     }
 
     #[test]
+    fn test_crypto_kem_enc_from_reader() {
+        use crate::api::{CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES};
+
+        let mut c = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let mut ss = [0u8; CRYPTO_BYTES];
+        let pk = TestData::new().u8vec("mceliece8192128f_pk1");
+        assert_eq!(pk.len(), CRYPTO_PUBLICKEYBYTES);
+
+        let compare_ss = TestData::new().u8vec("mceliece8192128f_operations_ss");
+        let compare_ct = TestData::new().u8vec("mceliece8192128f_operations_enc1_ct");
+
+        let entropy_input = <[u8; 48]>::try_from(
+            TestData::new()
+                .u8vec("mceliece8192128f_operations_entropy_input")
+                .as_slice(),
+        )
+        .unwrap();
+
+        let mut rng_state = AesState::new();
+        rng_state.randombytes_init(entropy_input);
+
+        let mut second_seed = [0u8; 33];
+        second_seed[0] = 64;
+
+        rng_state.fill_bytes(&mut second_seed[1..]);
+
+        let mut reader = SliceReader { data: &pk, pos: 0 };
+        crate::streaming::crypto_kem_enc_from_reader(&mut c, &mut ss, &mut reader, &mut rng_state)
+            .unwrap();
+
+        assert_eq!(reader.pos, CRYPTO_PUBLICKEYBYTES);
+        assert_eq!(ss, compare_ss.as_slice());
+        assert_eq!(c, compare_ct.as_slice());
+    }
+
+    #[test]
     fn test_crypto_kem_keypair() {
         use crate::api::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 
@@ -428,5 +464,44 @@ mod tests {
 
         assert_eq!(compare_sk, sk_input);
         assert_eq!(compare_pk, pk_input);
+    }
+}
+
+#[cfg(test)]
+mod streaming_tests {
+    use super::*;
+    use rand::{rngs::StdRng, SeedableRng};
+    use crate::test_utils::{generate_public_key_bytes, SliceReader};
+
+    #[test]
+    fn test_crypto_kem_enc_from_reader_matches_enc() {
+        let pk = generate_public_key_bytes([0x55; 32]);
+        let mut c_direct = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let mut c_reader = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let mut ss_direct = [0u8; CRYPTO_BYTES];
+        let mut ss_reader = [0u8; CRYPTO_BYTES];
+
+        let mut rng_direct = StdRng::from_seed([0x99; 32]);
+        let mut rng_reader = StdRng::from_seed([0x99; 32]);
+
+        let _ = crypto_kem_enc(
+            &mut c_direct,
+            &mut ss_direct,
+            sub!(pk, 0, CRYPTO_PUBLICKEYBYTES),
+            &mut rng_direct,
+        );
+
+        let mut reader = SliceReader { data: &pk, pos: 0 };
+        crate::streaming::crypto_kem_enc_from_reader(
+            &mut c_reader,
+            &mut ss_reader,
+            &mut reader,
+            &mut rng_reader,
+        )
+        .unwrap();
+
+        assert_eq!(reader.pos, CRYPTO_PUBLICKEYBYTES);
+        assert_eq!(c_direct, c_reader);
+        assert_eq!(ss_direct, ss_reader);
     }
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -64,8 +64,10 @@ fn syndrome_from_reader<P: PublicKeyReader>(
     e: &[u8; SYS_N / 8],
 ) -> Result<(), P::Error> {
     const HAS_TAIL: bool = PK_NROWS % 8 != 0;
-    const CHECK_PADDING: bool =
-        cfg!(any(feature = "mceliece6960119", feature = "mceliece6960119f"));
+    const CHECK_PADDING: bool = cfg!(any(
+        feature = "mceliece6960119",
+        feature = "mceliece6960119f"
+    ));
 
     syndrome_core::<_, { HAS_TAIL }, { CHECK_PADDING }>(s, e, pk_reader)
 }
@@ -147,11 +149,13 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::{generate_public_key_bytes, SliceReader};
+    #[cfg(feature = "embedded-workspace")]
+    use crate::DecapsulationWorkspace;
     use crate::{
         decapsulate, keypair, CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES,
         CRYPTO_SECRETKEYBYTES,
     };
-    use crate::test_utils::{generate_public_key_bytes, SliceReader};
     use rand::{rngs::StdRng, SeedableRng};
     use std::convert::TryInto;
 
@@ -179,6 +183,12 @@ mod tests {
             encapsulate_from_reader(&mut reader, &mut ss1_buf, &mut enc_rng).unwrap();
 
         let mut ss2_buf = [0u8; CRYPTO_BYTES];
+        #[cfg(feature = "embedded-workspace")]
+        let ss2 = {
+            let mut workspace = DecapsulationWorkspace::new();
+            decapsulate(&ciphertext, &secret_key, &mut ss2_buf, &mut workspace)
+        };
+        #[cfg(not(feature = "embedded-workspace"))]
         let ss2 = decapsulate(&ciphertext, &secret_key, &mut ss2_buf);
 
         assert_eq!(reader.pos, CRYPTO_PUBLICKEYBYTES);

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,0 +1,290 @@
+//! Streaming public-key reader support.
+//!
+//! Public keys are consumed incrementally from a caller-supplied reader. The
+//! reader must supply exactly `CRYPTO_PUBLICKEYBYTES` bytes; `finish` enforces
+//! that no trailing data remains. For padding-sensitive variants
+//! (`mceliece6960119`/`mceliece6960119f`), nonzero padding bits trigger an
+//! explicit error. Any reader error causes encapsulation outputs to be zeroed.
+
+use crate::{
+    api::{CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES},
+    encrypt::gen_e,
+    encrypt::syndrome_core,
+    encrypt::RowReader,
+    macros::sub,
+    operations::derive_ss_from_e_and_c,
+    params::{PK_NROWS, SYND_BYTES, SYS_N},
+    Ciphertext, KeyBufferMut, SharedSecret,
+};
+use rand::{CryptoRng, RngCore};
+
+/// A byte source for a serialized public key.
+///
+/// Implementations should supply exactly `CRYPTO_PUBLICKEYBYTES` bytes in
+/// row-major order (PK_NROWS rows of PK_ROW_BYTES bytes).
+pub trait PublicKeyReader {
+    type Error;
+
+    /// Fill `buf` with the next public-key bytes.
+    ///
+    /// Return an error on short reads or I/O failure.
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error>;
+
+    /// Called after the public key has been read to enforce exact length.
+    ///
+    /// Implementations should return an error if trailing bytes remain.
+    fn finish(&mut self) -> Result<(), Self::Error>;
+
+    /// Called when padding bits are nonzero for padding-sensitive variants.
+    ///
+    /// Implementations should return an error describing invalid padding.
+    fn invalid_padding(&self) -> Self::Error;
+}
+
+impl<P: PublicKeyReader> RowReader for P {
+    type Error = P::Error;
+
+    fn read_row(&mut self, row: &mut [u8]) -> Result<(), Self::Error> {
+        self.read_exact(row)
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        PublicKeyReader::finish(self)
+    }
+
+    fn invalid_padding(&self) -> Self::Error {
+        PublicKeyReader::invalid_padding(self)
+    }
+}
+
+/// Syndrome computation using a streaming public key reader.
+fn syndrome_from_reader<P: PublicKeyReader>(
+    s: &mut [u8; PK_NROWS.div_ceil(8)],
+    pk_reader: &mut P,
+    e: &[u8; SYS_N / 8],
+) -> Result<(), P::Error> {
+    const HAS_TAIL: bool = PK_NROWS % 8 != 0;
+    const CHECK_PADDING: bool =
+        cfg!(any(feature = "mceliece6960119", feature = "mceliece6960119f"));
+
+    syndrome_core::<_, { HAS_TAIL }, { CHECK_PADDING }>(s, e, pk_reader)
+}
+
+/// Encryption routine using a streaming public key reader.
+///
+/// Returns an error if the reader fails, has trailing bytes, or if padding
+/// bits are nonzero for padding-sensitive variants.
+pub(crate) fn encrypt_from_reader<R, P>(
+    s: &mut [u8; CRYPTO_CIPHERTEXTBYTES],
+    pk_reader: &mut P,
+    e: &mut [u8; SYS_N / 8],
+    rng: &mut R,
+) -> Result<(), P::Error>
+where
+    R: CryptoRng + RngCore,
+    P: PublicKeyReader,
+{
+    gen_e(e, rng);
+    syndrome_from_reader(sub!(mut s, 0, PK_NROWS.div_ceil(8)), pk_reader, e)
+}
+
+/// KEM Encapsulation using a streaming public key reader.
+///
+/// On error, `c` and `key` are zeroed before the error is returned.
+/// Errors include short reads, trailing bytes, or invalid padding for
+/// padding-sensitive variants.
+pub(crate) fn crypto_kem_enc_from_reader<R, P>(
+    c: &mut [u8; CRYPTO_CIPHERTEXTBYTES],
+    key: &mut [u8; CRYPTO_BYTES],
+    pk_reader: &mut P,
+    rng: &mut R,
+) -> Result<(), P::Error>
+where
+    R: CryptoRng + RngCore,
+    P: PublicKeyReader,
+{
+    let mut e = [0u8; SYS_N / 8];
+
+    if let Err(err) = encrypt_from_reader(c, pk_reader, sub!(mut e, 0, SYS_N / 8), rng) {
+        c.fill(0);
+        key.fill(0);
+        return Err(err);
+    }
+
+    derive_ss_from_e_and_c(key, &e, sub!(c, 0, SYND_BYTES));
+    Ok(())
+}
+
+/// KEM Encapsulation using a streaming public key reader.
+///
+/// This is useful on memory-constrained systems where the public key cannot
+/// be kept fully in RAM.
+///
+/// Returns an error if the reader is short, has trailing bytes, or if
+/// padding bits are nonzero for padding-sensitive variants.
+pub fn encapsulate_from_reader<'shared_secret, R, P>(
+    public_key_reader: &mut P,
+    shared_secret_buf: &'shared_secret mut [u8; CRYPTO_BYTES],
+    rng: &mut R,
+) -> Result<(Ciphertext, SharedSecret<'shared_secret>), P::Error>
+where
+    R: CryptoRng + RngCore,
+    P: PublicKeyReader,
+{
+    let mut shared_secret_buf = KeyBufferMut::Borrowed(shared_secret_buf);
+    let mut ciphertext_buf = [0u8; CRYPTO_CIPHERTEXTBYTES];
+
+    crypto_kem_enc_from_reader(
+        &mut ciphertext_buf,
+        shared_secret_buf.as_mut(),
+        public_key_reader,
+        rng,
+    )?;
+
+    Ok((Ciphertext(ciphertext_buf), SharedSecret(shared_secret_buf)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        decapsulate, keypair, CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PUBLICKEYBYTES,
+        CRYPTO_SECRETKEYBYTES,
+    };
+    use crate::test_utils::{generate_public_key_bytes, SliceReader};
+    use rand::{rngs::StdRng, SeedableRng};
+    use std::convert::TryInto;
+
+    #[test]
+    fn test_encapsulate_from_reader_roundtrip() {
+        let mut pk_storage = vec![0u8; CRYPTO_PUBLICKEYBYTES];
+        let mut sk_storage = vec![0u8; CRYPTO_SECRETKEYBYTES];
+
+        let pk_array: &mut [u8; CRYPTO_PUBLICKEYBYTES] =
+            pk_storage.as_mut_slice().try_into().unwrap();
+        let sk_array: &mut [u8; CRYPTO_SECRETKEYBYTES] =
+            sk_storage.as_mut_slice().try_into().unwrap();
+
+        let mut keygen_rng = StdRng::from_seed([0x3C; 32]);
+        let (public_key, secret_key) = keypair(pk_array, sk_array, &mut keygen_rng);
+        let pk_bytes = public_key.as_array().to_vec();
+
+        let mut reader = SliceReader {
+            data: pk_bytes.as_slice(),
+            pos: 0,
+        };
+        let mut ss1_buf = [0u8; CRYPTO_BYTES];
+        let mut enc_rng = StdRng::from_seed([0x6A; 32]);
+        let (ciphertext, ss1) =
+            encapsulate_from_reader(&mut reader, &mut ss1_buf, &mut enc_rng).unwrap();
+
+        let mut ss2_buf = [0u8; CRYPTO_BYTES];
+        let ss2 = decapsulate(&ciphertext, &secret_key, &mut ss2_buf);
+
+        assert_eq!(reader.pos, CRYPTO_PUBLICKEYBYTES);
+        assert_eq!(ss1.as_array(), ss2.as_array());
+    }
+
+    #[test]
+    fn test_encapsulate_from_reader_rejects_trailing_bytes() {
+        let mut pk_bytes = generate_public_key_bytes([0x3C; 32]);
+        pk_bytes.push(0x00);
+
+        let mut reader = SliceReader {
+            data: pk_bytes.as_slice(),
+            pos: 0,
+        };
+        let mut ss_buf = [0u8; CRYPTO_BYTES];
+        let mut rng = StdRng::from_seed([0x6A; 32]);
+
+        assert!(encapsulate_from_reader(&mut reader, &mut ss_buf, &mut rng).is_err());
+    }
+
+    #[test]
+    fn test_encapsulate_from_reader_rejects_short_read() {
+        let mut pk_bytes = generate_public_key_bytes([0x3C; 32]);
+        pk_bytes.pop();
+
+        let mut reader = SliceReader {
+            data: pk_bytes.as_slice(),
+            pos: 0,
+        };
+        let mut ss_buf = [0u8; CRYPTO_BYTES];
+        let mut rng = StdRng::from_seed([0x6A; 32]);
+
+        assert!(encapsulate_from_reader(&mut reader, &mut ss_buf, &mut rng).is_err());
+    }
+
+    #[test]
+    #[cfg(any(feature = "mceliece6960119", feature = "mceliece6960119f"))]
+    fn test_encapsulate_from_reader_rejects_invalid_padding() {
+        let mut pk_bytes = generate_public_key_bytes([0x3C; 32]);
+        let padding_mask = 0xFFu8 << (crate::params::PK_NCOLS % 8);
+        pk_bytes[crate::params::PK_ROW_BYTES - 1] |= padding_mask;
+
+        let mut reader = SliceReader {
+            data: pk_bytes.as_slice(),
+            pos: 0,
+        };
+        let mut ss_buf = [0u8; CRYPTO_BYTES];
+        let mut rng = StdRng::from_seed([0x6A; 32]);
+
+        assert!(encapsulate_from_reader(&mut reader, &mut ss_buf, &mut rng).is_err());
+    }
+
+    #[test]
+    fn test_crypto_kem_enc_from_reader_zeroes_on_short_read() {
+        let mut pk_bytes = generate_public_key_bytes([0x3C; 32]);
+        pk_bytes.pop();
+
+        let mut reader = SliceReader {
+            data: pk_bytes.as_slice(),
+            pos: 0,
+        };
+        let mut c = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let mut key = [0u8; CRYPTO_BYTES];
+        let mut rng = StdRng::from_seed([0x6A; 32]);
+
+        assert!(crypto_kem_enc_from_reader(&mut c, &mut key, &mut reader, &mut rng).is_err());
+        assert!(c.iter().all(|&byte| byte == 0));
+        assert!(key.iter().all(|&byte| byte == 0));
+    }
+
+    #[test]
+    fn test_crypto_kem_enc_from_reader_zeroes_on_trailing_bytes() {
+        let mut pk_bytes = generate_public_key_bytes([0x3C; 32]);
+        pk_bytes.push(0x00);
+
+        let mut reader = SliceReader {
+            data: pk_bytes.as_slice(),
+            pos: 0,
+        };
+        let mut c = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let mut key = [0u8; CRYPTO_BYTES];
+        let mut rng = StdRng::from_seed([0x6A; 32]);
+
+        assert!(crypto_kem_enc_from_reader(&mut c, &mut key, &mut reader, &mut rng).is_err());
+        assert!(c.iter().all(|&byte| byte == 0));
+        assert!(key.iter().all(|&byte| byte == 0));
+    }
+
+    #[test]
+    #[cfg(any(feature = "mceliece6960119", feature = "mceliece6960119f"))]
+    fn test_crypto_kem_enc_from_reader_zeroes_on_invalid_padding() {
+        let mut pk_bytes = generate_public_key_bytes([0x3C; 32]);
+        let padding_mask = 0xFFu8 << (crate::params::PK_NCOLS % 8);
+        pk_bytes[crate::params::PK_ROW_BYTES - 1] |= padding_mask;
+
+        let mut reader = SliceReader {
+            data: pk_bytes.as_slice(),
+            pos: 0,
+        };
+        let mut c = [0u8; CRYPTO_CIPHERTEXTBYTES];
+        let mut key = [0u8; CRYPTO_BYTES];
+        let mut rng = StdRng::from_seed([0x6A; 32]);
+
+        assert!(crypto_kem_enc_from_reader(&mut c, &mut key, &mut reader, &mut rng).is_err());
+        assert!(c.iter().all(|&byte| byte == 0));
+        assert!(key.iter().all(|&byte| byte == 0));
+    }
+}

--- a/src/test_katkem.rs
+++ b/src/test_katkem.rs
@@ -13,6 +13,8 @@ use std::io::Write;
 
 use crate::nist_aes_rng::AesState;
 use crate::test_utils::TestData;
+#[cfg(feature = "embedded-workspace")]
+use crate::DecapsulationWorkspace;
 use crate::{decapsulate, encapsulate, keypair, keypair_boxed};
 use crate::{
     CRYPTO_BYTES, CRYPTO_CIPHERTEXTBYTES, CRYPTO_PRIMITIVE, CRYPTO_PUBLICKEYBYTES,
@@ -254,6 +256,12 @@ pub(crate) fn create_response_file(filepath: &str) -> R {
 
         let (pk, sk) = keypair(&mut pk_buf, &mut sk_buf, &mut tc_rng);
         let (ct, ss) = encapsulate(&pk, &mut ss_buf1, &mut tc_rng);
+        #[cfg(feature = "embedded-workspace")]
+        let ss2 = {
+            let mut workspace = DecapsulationWorkspace::new();
+            decapsulate(&ct, &sk, &mut ss_buf2, &mut workspace)
+        };
+        #[cfg(not(feature = "embedded-workspace"))]
         let ss2 = decapsulate(&ct, &sk, &mut ss_buf2);
 
         tc.pk = *pk.as_array();
@@ -309,6 +317,12 @@ pub(crate) fn verify(filepath: &str) -> R {
 
         let (pk, sk) = keypair(&mut pk_buf, &mut sk_buf, &mut rng);
         let (ct, ss) = encapsulate(&pk, &mut ss_buf1, &mut rng);
+        #[cfg(feature = "embedded-workspace")]
+        let ss2 = {
+            let mut workspace = DecapsulationWorkspace::new();
+            decapsulate(&ct, &sk, &mut ss_buf2, &mut workspace)
+        };
+        #[cfg(not(feature = "embedded-workspace"))]
         let ss2 = decapsulate(&ct, &sk, &mut ss_buf2);
 
         actual.pk = *pk.as_array();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,5 +1,10 @@
 #![cfg(test)]
 
+use crate::api::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
+use crate::streaming::PublicKeyReader;
+use rand::{rngs::StdRng, SeedableRng};
+use std::convert::TryInto;
+
 macro_rules! impl_parser_per_type {
     ($name:ident, $bitsize:expr, $t:ty) => {
         /// Parses a testdata file and returns a vector of $ty stored for the given `search_key`.
@@ -78,4 +83,50 @@ impl TestData {
     impl_parser_per_type!(i16vec, 16, i16);
     //impl_parser_per_type!(i32vec, 32, i32);
     //impl_parser_per_type!(i64vec, 64, i64);
+}
+
+pub(crate) struct SliceReader<'a> {
+    pub(crate) data: &'a [u8],
+    pub(crate) pos: usize,
+}
+
+impl<'a> PublicKeyReader for SliceReader<'a> {
+    type Error = ();
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        let end = self.pos + buf.len();
+        if end > self.data.len() {
+            return Err(());
+        }
+        buf.copy_from_slice(&self.data[self.pos..end]);
+        self.pos = end;
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        if self.pos == self.data.len() {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    fn invalid_padding(&self) -> Self::Error {
+        ()
+    }
+}
+
+pub(crate) fn generate_public_key_bytes(seed: [u8; 32]) -> std::vec::Vec<u8> {
+    let mut pk_storage = vec![0u8; CRYPTO_PUBLICKEYBYTES];
+    let mut sk_storage = vec![0u8; CRYPTO_SECRETKEYBYTES];
+
+    let pk_array: &mut [u8; CRYPTO_PUBLICKEYBYTES] =
+        pk_storage.as_mut_slice().try_into().unwrap();
+    let sk_array: &mut [u8; CRYPTO_SECRETKEYBYTES] =
+        sk_storage.as_mut_slice().try_into().unwrap();
+
+    let mut keygen_rng = StdRng::from_seed(seed);
+    crate::operations::crypto_kem_keypair(pk_array, sk_array, &mut keygen_rng);
+
+    pk_storage
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -120,10 +120,8 @@ pub(crate) fn generate_public_key_bytes(seed: [u8; 32]) -> std::vec::Vec<u8> {
     let mut pk_storage = vec![0u8; CRYPTO_PUBLICKEYBYTES];
     let mut sk_storage = vec![0u8; CRYPTO_SECRETKEYBYTES];
 
-    let pk_array: &mut [u8; CRYPTO_PUBLICKEYBYTES] =
-        pk_storage.as_mut_slice().try_into().unwrap();
-    let sk_array: &mut [u8; CRYPTO_SECRETKEYBYTES] =
-        sk_storage.as_mut_slice().try_into().unwrap();
+    let pk_array: &mut [u8; CRYPTO_PUBLICKEYBYTES] = pk_storage.as_mut_slice().try_into().unwrap();
+    let sk_array: &mut [u8; CRYPTO_SECRETKEYBYTES] = sk_storage.as_mut_slice().try_into().unwrap();
 
     let mut keygen_rng = StdRng::from_seed(seed);
     crate::operations::crypto_kem_keypair(pk_array, sk_array, &mut keygen_rng);

--- a/tests/alloc.rs
+++ b/tests/alloc.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "alloc")]
 
+#[cfg(feature = "embedded-workspace")]
+use classic_mceliece_rust::DecapsulationWorkspace;
 use classic_mceliece_rust::{decapsulate_boxed, encapsulate_boxed, keypair, keypair_boxed};
 use classic_mceliece_rust::{CRYPTO_PUBLICKEYBYTES, CRYPTO_SECRETKEYBYTES};
 use std::thread;
@@ -57,6 +59,12 @@ fn boxed_versions_dont_trash_the_stack() {
 
         let (public_key, secret_key) = keypair_boxed(&mut rng);
         let (ciphertext, shared_secret_bob) = encapsulate_boxed(&public_key, &mut rng);
+        #[cfg(feature = "embedded-workspace")]
+        let shared_secret_alice = {
+            let mut workspace = DecapsulationWorkspace::new();
+            decapsulate_boxed(&ciphertext, &secret_key, &mut workspace)
+        };
+        #[cfg(not(feature = "embedded-workspace"))]
         let shared_secret_alice = decapsulate_boxed(&ciphertext, &secret_key);
         assert_eq!(shared_secret_bob.as_array(), shared_secret_alice.as_array());
     }


### PR DESCRIPTION
This is done to support enc/dec in embedded systems with constrained memory. It was tested on rp2350 and esp32-c6 (uses < 64kb of active RAM).
 
- add RowReader-based syndrome_core shared by streaming/in-memory paths
- dedup streaming encrypt/encap and shared-secret derivation
- centralize test helpers; move run-examples and add all variants test runner (release mode)
- streaming examples/fixtures for file/no-std paths